### PR TITLE
Add project membership model

### DIFF
--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -5,3 +5,4 @@ export { Project } from "./project";
 export { Upload } from "./upload";
 export { KBOBMaterial } from "./kbob";
 export { MaterialDeletion } from "./material-deletion";
+export { ProjectMembership } from "./project-membership";

--- a/src/models/project-membership.ts
+++ b/src/models/project-membership.ts
@@ -1,0 +1,46 @@
+import mongoose from "mongoose";
+
+interface IProjectMembership {
+  projectId: mongoose.Types.ObjectId;
+  userId: string;
+  role: "viewer" | "editor" | "uploader" | "manager";
+  invitedBy?: string;
+  status: "pending" | "accepted";
+}
+
+const projectMembershipSchema = new mongoose.Schema<IProjectMembership>(
+  {
+    projectId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Project",
+      required: true,
+    },
+    userId: {
+      type: String,
+      required: true,
+    },
+    role: {
+      type: String,
+      enum: ["viewer", "editor", "uploader", "manager"],
+      default: "viewer",
+    },
+    invitedBy: {
+      type: String,
+    },
+    status: {
+      type: String,
+      enum: ["pending", "accepted"],
+      default: "pending",
+    },
+  },
+  {
+    timestamps: true,
+    strict: true,
+  }
+);
+
+projectMembershipSchema.index({ projectId: 1, userId: 1 }, { unique: true });
+
+export const ProjectMembership =
+  mongoose.models.ProjectMembership ||
+  mongoose.model<IProjectMembership>("ProjectMembership", projectMembershipSchema);


### PR DESCRIPTION
## Summary
- add `ProjectMembership` model with project and user references
- export `ProjectMembership` from models index

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npx tsc --noEmit` *(fails: many existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_683bf677d9b88320840ceac8c3c89186