### PR TITLE
Add project membership routes

### DIFF
--- a/src/app/api/projects/[id]/members/[memberId]/route.ts
+++ b/src/app/api/projects/[id]/members/[memberId]/route.ts
@@ -1,0 +1,109 @@
+import { connectToDatabase } from "@/lib/mongodb";
+import { Project, ProjectMembership } from "@/models";
+import { auth } from "@clerk/nextjs/server";
+import mongoose from "mongoose";
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: { id: string; memberId: string } }
+) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (
+      !mongoose.Types.ObjectId.isValid(params.id) ||
+      !mongoose.Types.ObjectId.isValid(params.memberId)
+    ) {
+      return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+    }
+
+    await connectToDatabase();
+
+    const membership = await ProjectMembership.findById(params.memberId);
+    if (!membership) {
+      return NextResponse.json({ error: "Membership not found" }, { status: 404 });
+    }
+
+    const project = await Project.findById(membership.projectId).lean();
+    if (!project) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+
+    const body = await request.json();
+
+    if (body.status === "accepted") {
+      if (membership.userId !== userId) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+      membership.status = "accepted";
+    }
+
+    if (body.role) {
+      if (project.userId !== userId) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+      membership.role = body.role;
+    }
+
+    await membership.save();
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Failed to update member:", error);
+    return NextResponse.json(
+      { error: "Failed to update member" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string; memberId: string } }
+) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (
+      !mongoose.Types.ObjectId.isValid(params.id) ||
+      !mongoose.Types.ObjectId.isValid(params.memberId)
+    ) {
+      return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+    }
+
+    await connectToDatabase();
+
+    const membership = await ProjectMembership.findById(params.memberId);
+    if (!membership) {
+      return NextResponse.json({ error: "Membership not found" }, { status: 404 });
+    }
+
+    const project = await Project.findById(membership.projectId).lean();
+    if (!project) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+
+    if (project.userId !== userId && membership.userId !== userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    await ProjectMembership.deleteOne({ _id: membership._id });
+
+    return new Response(null, { status: 204 });
+  } catch (error) {
+    console.error("Failed to remove member:", error);
+    return NextResponse.json(
+      { error: "Failed to remove member" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/projects/[id]/members/route.ts
+++ b/src/app/api/projects/[id]/members/route.ts
@@ -1,0 +1,150 @@
+import { connectToDatabase } from "@/lib/mongodb";
+import { Project, ProjectMembership } from "@/models";
+import { userHasPaidPlan } from "@/lib/services/billing-service";
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import mongoose from "mongoose";
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(params.id)) {
+      return NextResponse.json({ error: "Invalid project ID" }, { status: 400 });
+    }
+
+    await connectToDatabase();
+
+    const projectId = new mongoose.Types.ObjectId(params.id);
+
+    const project = await Project.findById(projectId).lean();
+    if (!project) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+
+    const isOwner = project.userId === userId;
+    if (!isOwner) {
+      const membership = await ProjectMembership.findOne({
+        projectId,
+        userId,
+        status: "accepted",
+      });
+      if (!membership) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+    }
+
+    const memberships = await ProjectMembership.find({ projectId }).lean();
+
+    const accepted: any[] = [];
+    const pending: any[] = [];
+
+    for (const m of memberships) {
+      let user = null;
+      try {
+        user = await clerkClient.users.getUser(m.userId);
+      } catch {
+        // ignore errors fetching user info
+      }
+      const data = {
+        id: m._id.toString(),
+        userId: m.userId,
+        role: m.role,
+        status: m.status,
+        user: user
+          ? {
+              id: user.id,
+              name: `${user.firstName || ""} ${user.lastName || ""}`.trim(),
+              imageUrl: user.imageUrl,
+            }
+          : null,
+      };
+      if (m.status === "accepted") {
+        accepted.push(data);
+      } else {
+        pending.push(data);
+      }
+    }
+
+    return NextResponse.json({ accepted, pending });
+  } catch (error) {
+    console.error("Failed to fetch members:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch members" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const invitedUserId = body.userId;
+    const role = body.role || "member";
+    if (!invitedUserId) {
+      return NextResponse.json({ error: "userId required" }, { status: 400 });
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(params.id)) {
+      return NextResponse.json({ error: "Invalid project ID" }, { status: 400 });
+    }
+
+    await connectToDatabase();
+    const projectId = new mongoose.Types.ObjectId(params.id);
+
+    const project = await Project.findById(projectId).lean();
+    if (!project) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+    if (project.userId !== userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const hasPlan = await userHasPaidPlan(userId);
+    if (!hasPlan) {
+      return NextResponse.json(
+        { error: "Paid plan required" },
+        { status: 402 }
+      );
+    }
+
+    const existing = await ProjectMembership.findOne({
+      projectId,
+      userId: invitedUserId,
+    });
+    if (existing) {
+      return NextResponse.json({ error: "Already invited" }, { status: 400 });
+    }
+
+    const membership = await ProjectMembership.create({
+      projectId,
+      userId: invitedUserId,
+      role,
+      status: "pending",
+    });
+
+    return NextResponse.json({ id: membership._id.toString() });
+  } catch (error) {
+    console.error("Failed to invite member:", error);
+    return NextResponse.json(
+      { error: "Failed to invite member" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/services/billing-service.ts
+++ b/src/lib/services/billing-service.ts
@@ -1,0 +1,4 @@
+export async function userHasPaidPlan(_userId: string): Promise<boolean> {
+  // TODO: Integrate with actual billing/subscription logic
+  return true;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -5,3 +5,4 @@ export { Project } from "./project";
 export { Upload } from "./upload";
 export { KBOBMaterial } from "./kbob";
 export { MaterialDeletion } from "./material-deletion";
+export { ProjectMembership } from "./project-membership";

--- a/src/models/project-membership.ts
+++ b/src/models/project-membership.ts
@@ -1,0 +1,33 @@
+import mongoose from "mongoose";
+
+interface IProjectMembership {
+  projectId: mongoose.Types.ObjectId;
+  userId: string;
+  role: string;
+  status: "pending" | "accepted";
+}
+
+const projectMembershipSchema = new mongoose.Schema<IProjectMembership>(
+  {
+    projectId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Project",
+      required: true,
+      index: true,
+    },
+    userId: { type: String, required: true, index: true },
+    role: { type: String, default: "member" },
+    status: {
+      type: String,
+      enum: ["pending", "accepted"],
+      default: "pending",
+    },
+  },
+  { timestamps: true }
+);
+
+projectMembershipSchema.index({ projectId: 1, userId: 1 }, { unique: true });
+
+export const ProjectMembership =
+  mongoose.models.ProjectMembership ||
+  mongoose.model<IProjectMembership>("ProjectMembership", projectMembershipSchema);


### PR DESCRIPTION
## Summary
- create `ProjectMembership` model and export it
- add a dummy billing service for paid plan checks
- implement project members API with invite, update and delete

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_683bf68653b48320a645288d2c693cc2