### PR TITLE
Fix warnings

### DIFF
--- a/src/models/kbob.ts
+++ b/src/models/kbob.ts
@@ -19,7 +19,7 @@ interface KBOBMaterialModel extends mongoose.Model<IKBOBMaterial> {
 const kbobSchema = new mongoose.Schema<IKBOBMaterial, KBOBMaterialModel>(
   {
     KBOB_ID: { type: Number, required: true, index: true },
-    Name: { type: String, required: true, index: true },
+    Name: { type: String, required: true },
     Category: { type: String },
     GWP: { type: Number, required: true },
     UBP: { type: Number, required: true },
@@ -36,7 +36,6 @@ const kbobSchema = new mongoose.Schema<IKBOBMaterial, KBOBMaterialModel>(
 
 // Add indexes for better query performance
 kbobSchema.index({ Name: 1 });
-kbobSchema.index({ Category: 1 });
 
 // Add a static method to find valid materials
 kbobSchema.static("findValidMaterials", function () {

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,0 +1,1 @@
+export { default } from 'next/error';


### PR DESCRIPTION
## Summary
- keep index on `Name` instead of on `Category`
- add an `_error.tsx` page for Vercel routing

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and other warnings)*
- `npm run build` *(fails to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6841cdd0a22c83208f167dd45d9d9591