### PR TITLE
Add integrated support ticket system

### DIFF
--- a/src/app/admin/support/page.tsx
+++ b/src/app/admin/support/page.tsx
@@ -1,0 +1,18 @@
+import { AdminSupportPage } from "@/components/admin-support-page";
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Support Admin",
+  description: "Manage support tickets",
+  robots: { index: false, follow: false, noarchive: true },
+};
+
+export default async function Page() {
+  const { userId } = await auth();
+  if (!userId || userId !== process.env.ADMIN_USER_ID) {
+    redirect("/");
+  }
+  return <AdminSupportPage />;
+}

--- a/src/app/api/support/[id]/route.ts
+++ b/src/app/api/support/[id]/route.ts
@@ -1,0 +1,68 @@
+import { auth } from "@clerk/nextjs/server";
+import { connectToDatabase } from "@/lib/mongodb";
+import { SupportTicket } from "@/models";
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const { userId } = await auth();
+  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
+
+  await connectToDatabase();
+
+  const ticket = await SupportTicket.findById(params.id).lean();
+  if (!ticket) return new NextResponse("Not Found", { status: 404 });
+
+  const isAdmin = process.env.ADMIN_USER_ID && userId === process.env.ADMIN_USER_ID;
+  if (!isAdmin && ticket.userId !== userId) {
+    return new NextResponse("Forbidden", { status: 403 });
+  }
+
+  return NextResponse.json({
+    id: ticket._id.toString(),
+    userId: ticket.userId,
+    subject: ticket.subject,
+    status: ticket.status,
+    messages: ticket.messages,
+    createdAt: ticket.createdAt,
+  });
+}
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const { userId } = await auth();
+  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
+
+  await connectToDatabase();
+
+  const ticket = await SupportTicket.findById(params.id);
+  if (!ticket) return new NextResponse("Not Found", { status: 404 });
+
+  const isAdmin = process.env.ADMIN_USER_ID && userId === process.env.ADMIN_USER_ID;
+  if (!isAdmin && ticket.userId !== userId) {
+    return new NextResponse("Forbidden", { status: 403 });
+  }
+
+  const body = await req.json();
+  if (body.message) {
+    ticket.messages.push({
+      sender: isAdmin ? "admin" : "user",
+      text: body.message,
+      createdAt: new Date(),
+    });
+  }
+  if (isAdmin && body.status) {
+    ticket.status = body.status;
+  } else if (!isAdmin) {
+    ticket.status = "open";
+  }
+  await ticket.save();
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/support/route.ts
+++ b/src/app/api/support/route.ts
@@ -1,0 +1,51 @@
+import { auth } from "@clerk/nextjs/server";
+import { connectToDatabase } from "@/lib/mongodb";
+import { SupportTicket } from "@/models";
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
+
+  await connectToDatabase();
+
+  const isAdmin = process.env.ADMIN_USER_ID &&
+    userId === process.env.ADMIN_USER_ID;
+
+  const tickets = await SupportTicket.find(isAdmin ? {} : { userId })
+    .sort({ createdAt: -1 })
+    .lean();
+
+  const data = tickets.map((t: any) => ({
+    id: t._id.toString(),
+    userId: t.userId,
+    subject: t.subject,
+    status: t.status,
+    messages: t.messages,
+    createdAt: t.createdAt,
+  }));
+
+  return NextResponse.json(data);
+}
+
+export async function POST(req: Request) {
+  const { userId } = await auth();
+  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
+
+  const body = await req.json();
+  if (!body.subject || !body.message) {
+    return NextResponse.json({ error: "Subject and message required" }, { status: 400 });
+  }
+
+  await connectToDatabase();
+
+  const ticket = await SupportTicket.create({
+    userId,
+    subject: body.subject,
+    messages: [{ sender: "user", text: body.message }],
+  });
+
+  return NextResponse.json({ id: ticket._id.toString() });
+}

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,0 +1,11 @@
+import { SupportPage } from "@/components/support-page";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Support",
+  description: "Get help or report issues",
+};
+
+export default function Page() {
+  return <SupportPage />;
+}

--- a/src/components/admin-support-page.tsx
+++ b/src/components/admin-support-page.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface Ticket {
+  id: string;
+  userId: string;
+  subject: string;
+  status: string;
+  messages: { sender: string; text: string; createdAt: string }[];
+}
+
+export function AdminSupportPage() {
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [reply, setReply] = useState<Record<string, string>>({});
+
+  const fetchTickets = async () => {
+    const res = await fetch("/api/support");
+    const data = await res.json();
+    setTickets(data);
+  };
+
+  useEffect(() => {
+    fetchTickets();
+  }, []);
+
+  const sendReply = async (id: string) => {
+    const text = reply[id];
+    if (!text) return;
+    await fetch(`/api/support/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: text }),
+    });
+    setReply({ ...reply, [id]: "" });
+    fetchTickets();
+  };
+
+  const updateStatus = async (id: string, status: string) => {
+    await fetch(`/api/support/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status }),
+    });
+    fetchTickets();
+  };
+
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      {tickets.map((ticket) => (
+        <Card key={ticket.id} className="max-w-2xl">
+          <CardHeader>
+            <CardTitle>
+              {ticket.subject} – {ticket.userId}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              {ticket.messages.map((m, i) => (
+                <div key={i} className="text-sm">
+                  <span className="font-medium mr-1">{m.sender}:</span>
+                  {m.text}
+                </div>
+              ))}
+            </div>
+            <div className="flex gap-2">
+              <Textarea
+                placeholder="Reply..."
+                value={reply[ticket.id] || ""}
+                onChange={(e) =>
+                  setReply({ ...reply, [ticket.id]: e.target.value })
+                }
+              />
+              <Button
+                type="button"
+                onClick={() => sendReply(ticket.id)}
+                disabled={!reply[ticket.id]}
+              >
+                Send
+              </Button>
+            </div>
+            <div className="pt-2">
+              <Select
+                value={ticket.status}
+                onValueChange={(value) => updateStatus(ticket.id, value)}
+              >
+                <SelectTrigger className="w-[150px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="open">Open</SelectItem>
+                  <SelectItem value="closed">Closed</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/navigation-bar.tsx
+++ b/src/components/navigation-bar.tsx
@@ -19,6 +19,7 @@ import {
   Sun,
   ExternalLink,
   Construction,
+  MessageCircle,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -532,6 +533,13 @@ export function NavigationBar({ currentProject, notifications }: NavBarProps) {
               <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
               <span className="sr-only">Toggle theme</span>
             </Button>
+
+            <Link href="/support">
+              <Button variant="ghost" size="icon" className="h-8 w-8">
+                <MessageCircle className="h-4 w-4" />
+                <span className="sr-only">Support</span>
+              </Button>
+            </Link>
 
             <HelpDialog />
 

--- a/src/components/support-page.tsx
+++ b/src/components/support-page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface Ticket {
+  id: string;
+  subject: string;
+  status: string;
+  messages: { sender: string; text: string; createdAt: string }[];
+}
+
+export function SupportPage() {
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [subject, setSubject] = useState("");
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [reply, setReply] = useState<Record<string, string>>({});
+
+  const fetchTickets = async () => {
+    const res = await fetch("/api/support");
+    const data = await res.json();
+    setTickets(data);
+  };
+
+  useEffect(() => {
+    fetchTickets();
+  }, []);
+
+  const createTicket = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!subject || !message) return;
+    setLoading(true);
+    await fetch("/api/support", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ subject, message }),
+    });
+    setSubject("");
+    setMessage("");
+    await fetchTickets();
+    setLoading(false);
+  };
+
+  const sendReply = async (id: string) => {
+    const text = reply[id];
+    if (!text) return;
+    await fetch(`/api/support/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: text }),
+    });
+    setReply({ ...reply, [id]: "" });
+    fetchTickets();
+  };
+
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      <Card className="max-w-2xl">
+        <CardHeader>
+          <CardTitle>Create Support Ticket</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={createTicket} className="space-y-4">
+            <Input
+              placeholder="Subject"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+            />
+            <Textarea
+              placeholder="Describe your issue"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+            />
+            <Button type="submit" disabled={loading}>
+              Submit
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+      {tickets.map((ticket) => (
+        <Card key={ticket.id} className="max-w-2xl">
+          <CardHeader>
+            <CardTitle>
+              {ticket.subject}{" "}
+              <span className="text-sm font-normal text-muted-foreground">
+                ({ticket.status})
+              </span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              {ticket.messages.map((m, i) => (
+                <div key={i} className="text-sm">
+                  <span className="font-medium mr-1">{m.sender}:</span>
+                  {m.text}
+                </div>
+              ))}
+            </div>
+            <div className="flex gap-2">
+              <Textarea
+                placeholder="Reply..."
+                value={reply[ticket.id] || ""}
+                onChange={(e) =>
+                  setReply({ ...reply, [ticket.id]: e.target.value })
+                }
+              />
+              <Button
+                type="button"
+                onClick={() => sendReply(ticket.id)}
+                disabled={!reply[ticket.id]}
+              >
+                Send
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -5,3 +5,5 @@ export { Project } from "./project";
 export { Upload } from "./upload";
 export { KBOBMaterial } from "./kbob";
 export { MaterialDeletion } from "./material-deletion";
+
+export { SupportTicket } from "./support-ticket";

--- a/src/models/support-ticket.ts
+++ b/src/models/support-ticket.ts
@@ -1,0 +1,39 @@
+import mongoose from "mongoose";
+
+interface Message {
+  sender: "user" | "admin";
+  text: string;
+  createdAt: Date;
+}
+
+interface ISupportTicket extends mongoose.Document {
+  userId: string;
+  subject: string;
+  messages: Message[];
+  status: "open" | "closed";
+}
+
+const messageSchema = new mongoose.Schema<Message>(
+  {
+    sender: { type: String, enum: ["user", "admin"], required: true },
+    text: { type: String, required: true },
+    createdAt: { type: Date, default: Date.now },
+  },
+  { _id: false }
+);
+
+const supportTicketSchema = new mongoose.Schema<ISupportTicket>(
+  {
+    userId: { type: String, required: true, index: true },
+    subject: { type: String, required: true },
+    messages: { type: [messageSchema], default: [] },
+    status: { type: String, enum: ["open", "closed"], default: "open" },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+export const SupportTicket =
+  mongoose.models.SupportTicket ||
+  mongoose.model<ISupportTicket>("SupportTicket", supportTicketSchema);


### PR DESCRIPTION
## Summary
- add SupportTicket mongoose model and exports
- expose `/api/support` and `/api/support/[id]` to submit and manage tickets
- user Support page with ticket list and messaging
- admin interface to manage tickets
- link Support entry in navigation bar

## Testing
- `npx --yes next lint` *(fails: react/no-unescaped-entities etc.)*
- `npm run build` *(fails: failed to fetch Nunito Sans font)*

------
https://chatgpt.com/codex/tasks/task_e_68433bd9591c8320879a6b6fd9c84334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a support ticket system, allowing users to create, view, and reply to support requests.
	- Added an admin interface for managing and responding to support tickets, including status updates.
	- Added support section accessible from the navigation bar.
- **Bug Fixes**
	- Not applicable.
- **Documentation**
	- Not applicable.
- **Chores**
	- Not applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->