### PR TITLE
Add Oekobaudat support

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.159.0",
     "zod": "^3.23.8",
-    "zustand": "^5.0.1"
+    "zustand": "^5.0.1",
+    "adm-zip": "^0.5.10"
   },
   "devDependencies": {
     "@types/mongoose": "^5.11.97",

--- a/scripts/import-oekobaudat.ts
+++ b/scripts/import-oekobaudat.ts
@@ -1,0 +1,57 @@
+import fs from 'fs/promises';
+import path from 'path';
+import fetch from 'node-fetch';
+import AdmZip from 'adm-zip';
+import mongoose from 'mongoose';
+import { connectToDatabase } from '@/lib/mongodb';
+import { OekobaudatMaterial } from '@/models';
+
+const DATA_URL = process.env.OEKOBAUDAT_URL ||
+  'https://www.oekobaudat.de/downloads/OEKOBAUDAT_2024_json.zip';
+
+async function downloadFile(url: string, dest: string) {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to download dataset: ${res.status} ${res.statusText}`);
+  }
+  const buffer = Buffer.from(await res.arrayBuffer());
+  await fs.writeFile(dest, buffer);
+}
+
+async function importOekobaudat() {
+  await connectToDatabase();
+  const tmpZip = path.join('/tmp', 'oekobaudat.zip');
+  await downloadFile(DATA_URL, tmpZip);
+
+  const zip = new AdmZip(tmpZip);
+  const entries = zip.getEntries();
+  let count = 0;
+  for (const entry of entries) {
+    if (entry.entryName.toLowerCase().endsWith('.json')) {
+      const content = entry.getData().toString('utf8');
+      const json = JSON.parse(content);
+      const material = {
+        uuid: json.uuid || json.GUID || json.id,
+        name: json.name || json.Name || json['Name_DE'],
+        category: json.category || json['Category'],
+        subCategory: json.subCategory || json['SubCategory'],
+        gwp: json.GWP || json['GWP_GESAMT'],
+        penrt: json.PENRT || json['PENRT_GESAMT'],
+      };
+      if (!material.uuid || !material.name) continue;
+      await OekobaudatMaterial.updateOne(
+        { uuid: material.uuid },
+        { $set: material },
+        { upsert: true }
+      );
+      count++;
+    }
+  }
+  console.log(`Imported ${count} Oekobaudat records`);
+  await mongoose.connection.close();
+}
+
+importOekobaudat().catch((err) => {
+  console.error('Import failed:', err);
+  process.exit(1);
+});

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -4,4 +4,5 @@ export { MaterialUsage } from "./material-usage";
 export { Project } from "./project";
 export { Upload } from "./upload";
 export { KBOBMaterial } from "./kbob";
+export { OekobaudatMaterial } from "./oekobaudat";
 export { MaterialDeletion } from "./material-deletion";

--- a/src/models/oekobaudat.ts
+++ b/src/models/oekobaudat.ts
@@ -1,0 +1,32 @@
+import mongoose from "mongoose";
+
+export interface IOekobaudatMaterial {
+  uuid: string;
+  name: string;
+  category?: string;
+  subCategory?: string;
+  gwp?: number;
+  penrt?: number;
+}
+
+const oekobaudatSchema = new mongoose.Schema<IOekobaudatMaterial>(
+  {
+    uuid: { type: String, required: true, index: true },
+    name: { type: String, required: true, index: true },
+    category: { type: String },
+    subCategory: { type: String },
+    gwp: { type: Number },
+    penrt: { type: Number },
+  },
+  {
+    collection: "indicatorsOekobaudat",
+    strict: false,
+  }
+);
+
+oekobaudatSchema.index({ uuid: 1 });
+oekobaudatSchema.index({ name: 1 });
+
+export const OekobaudatMaterial =
+  (mongoose.models.OekobaudatMaterial as mongoose.Model<IOekobaudatMaterial>) ||
+  mongoose.model<IOekobaudatMaterial>("OekobaudatMaterial", oekobaudatSchema, "indicatorsOekobaudat");


### PR DESCRIPTION
## Summary
- add `OekobaudatMaterial` mongoose model
- expose the model in the models index
- add `adm-zip` dependency
- include a script to import Oekobaudat datasets

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68440c4517448320b4277a2fd750fa9f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated import of Oekobaudat material data into the system, enabling integration of updated material properties from external datasets.
- **Chores**
  - Introduced a new dependency to support ZIP file extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->