### PR TITLE
Update material ecoMaterial reference

### DIFF
--- a/src/types/material.ts
+++ b/src/types/material.ts
@@ -16,11 +16,16 @@ export interface IKBOBMaterial {
   "max density"?: number;
 }
 
+export interface IEcoMaterialRef {
+  source: string;
+  id: string;
+}
+
 export interface IMaterial {
   _id: string;
   name: string;
   projectId: string;
-  kbobMatchId?: string;
+  ecoMaterial?: IEcoMaterialRef;
   density?: number;
   gwp?: number;
   ubp?: number;


### PR DESCRIPTION
## Summary
- add generic `ecoMaterial` reference in Mongoose model
- update Material interface with `ecoMaterial` field

## Testing
- `npm run lint` *(fails: react lint errors)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684416e1ead083209118692cf67b03fd