### PR TITLE
Add indicator lookup helper

### DIFF
--- a/src/app/features/page.tsx
+++ b/src/app/features/page.tsx
@@ -187,7 +187,7 @@ export default function FeaturesPage() {
                 }
             ],
             stats: [
-                { label: "Free Projects", value: "3", icon: Building2 },
+                { label: "Free Projects per User", value: "3", icon: Building2 },
                 { label: "Uploads", value: "∞", icon: Upload },
                 { label: "Storage", value: "Unlimited", icon: HardDrive }
             ]

--- a/src/app/try/page.tsx
+++ b/src/app/try/page.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from "next";
+import TryNowPage from "@/components/try-now-page";
+
+export const metadata: Metadata = {
+  title: "Try Now - IfcLCA",
+  description: "Upload an IFC and preview results without an account",
+  robots: { index: false, follow: false, noarchive: true, nosnippet: true },
+};
+
+export default function TryPage() {
+  return <TryNowPage />;
+}

--- a/src/components/landing-page.tsx
+++ b/src/components/landing-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { motion, useScroll, useTransform, AnimatePresence, useMotionValue, useSpring } from "framer-motion";
 import { useInView } from "react-intersection-observer";
 import { Button } from "@/components/ui/button";
@@ -17,6 +17,8 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import Link from "next/link";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { fileTransferService } from "@/lib/file-transfer";
 import {
   ArrowRight,
   BarChart3,
@@ -48,6 +50,8 @@ import {
   BookOpen,
   Heart,
   Flag,
+  ArrowDown,
+  GitFork,
 } from "lucide-react";
 
 // Floating shapes component
@@ -57,17 +61,17 @@ const FloatingShapes = () => {
       {[...Array(6)].map((_, i) => (
         <motion.div
           key={i}
-          className="absolute w-64 h-64 rounded-full bg-gradient-to-r from-orange-400/10 to-blue-400/10 dark:from-orange-500/20 dark:to-blue-500/20 blur-3xl"
+          className="absolute w-64 h-64 rounded-full bg-gradient-to-r from-orange-400/5 to-blue-400/5 dark:from-orange-500/10 dark:to-blue-500/10 blur-3xl"
           animate={{
-            x: [0, 100, -100, 0],
-            y: [0, -100, 100, 0],
-            scale: [1, 1.2, 0.8, 1],
+            x: [0, 50, -50, 0],
+            y: [0, -30, 30, 0],
+            scale: [1, 1.1, 0.9, 1],
           }}
           transition={{
-            duration: 20 + i * 5,
+            duration: 30 + i * 5,
             repeat: Infinity,
             ease: "easeInOut",
-            delay: i * 2,
+            delay: i * 3,
           }}
           style={{
             left: `${Math.random() * 100}%`,
@@ -140,7 +144,7 @@ const FeatureModal = ({ feature, isOpen, onClose, githubMetrics = { stars: 0, co
             },
             {
               title: "Creator's Philosophy",
-              description: "Louis Trümpler releases all software under AGPL because he believes it drives our industry forward. Trust is essential for sustainability, and trust comes from openness.",
+              description: "Louis Trümpler releases IfcLCA under AGPL because he believes it drives our industry forward. Trust is essential for sustainability, and trust comes from openness.",
               icon: Heart,
             },
             {
@@ -182,9 +186,9 @@ const FeatureModal = ({ feature, isOpen, onClose, githubMetrics = { stars: 0, co
             },
           ],
           stats: [
-            { label: "IFC Elements", value: "100%" },
-            { label: "Parse Speed", value: "<5s" },
-            { label: "Accuracy", value: "99.9%" },
+            { label: "large IFC files", value: "100 MB+" },
+            { label: "Parse Speed", value: "<1min" },
+            { label: "IFC Coverage", value: "100%" },
           ],
           cta: {
             text: "See Documentation",
@@ -310,13 +314,13 @@ const FeatureModal = ({ feature, isOpen, onClose, githubMetrics = { stars: 0, co
             },
           ],
           stats: [
-            { label: "Process Time", value: "~30s" },
-            { label: "File Size", value: "100MB+" },
-            { label: "Elements", value: "10k+" },
+            { label: "Analysis Time", value: "~30s" },
+            { label: "Browser Support", value: "99%" },
+            { label: "No Upload", value: "0 MB" },
           ],
           cta: {
             text: "Try It Now",
-            href: "/sign-in?redirect_url=/",
+            href: "/try",
           },
         };
 
@@ -689,9 +693,45 @@ export default function LandingPage() {
     contributors: 0,
     commits: 0
   });
-  const heroRef = useRef(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const heroRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const { scrollYProgress } = useScroll();
   const y = useTransform(scrollYProgress, [0, 1], ["0%", "50%"]);
+  const router = useRouter();
+
+  // Headline carousel state
+  const [currentHeadlineIndex, setCurrentHeadlineIndex] = useState(0);
+  const headlines = [
+    {
+      prefix: "Life Cycle Assessment for the",
+      highlight: "Built Environment"
+    },
+    {
+      prefix: "Environmental Analysis for",
+      highlight: "IFC Building Models"
+    },
+    {
+      prefix: "Carbon Footprint Analysis for",
+      highlight: "Infrastructure Projects"
+    },
+    {
+      prefix: "Sustainability Metrics for",
+      highlight: "BIM Models"
+    },
+    {
+      prefix: "Instant LCA Reports for",
+      highlight: "Construction Projects"
+    }
+  ];
+
+  // Rotate headlines
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentHeadlineIndex((prev) => (prev + 1) % headlines.length);
+    }, 3000);
+    return () => clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     if (
@@ -789,7 +829,7 @@ export default function LandingPage() {
   const stats = [
     { value: 300, suffix: "+", label: "Materials" },
     { value: githubMetrics.stars, suffix: "", label: "GitHub Stars" },
-    { value: 3, suffix: "", label: "Free Projects" },
+    { value: 3, suffix: "", label: "Free Projects per User" },
     { value: 100, suffix: "%", label: "Open Source" },
   ];
 
@@ -816,6 +856,37 @@ export default function LandingPage() {
       rating: 5,
     },
   ];
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  }, []);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+
+    const file = e.dataTransfer.files[0];
+    if (file && file.name.toLowerCase().endsWith('.ifc')) {
+      // Pass the actual file to the service
+      fileTransferService.setPendingFile(file);
+      router.push('/try');
+    }
+  }, [router]);
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file && file.name.toLowerCase().endsWith('.ifc')) {
+      // Pass the actual file to the service
+      fileTransferService.setPendingFile(file);
+      router.push('/try');
+    }
+  };
 
   return (
     <div className={`min-h-screen flex flex-col ${isDarkMode ? "dark" : ""}`}>
@@ -849,6 +920,14 @@ export default function LandingPage() {
           </span>
         </motion.div>
         <nav className="hidden md:flex items-center space-x-4">
+          <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+            <Link
+              href="/try"
+              className="px-4 py-2 text-sm font-medium text-orange-600 hover:text-orange-700 dark:text-orange-400 dark:hover:text-orange-300 transition-colors"
+            >
+              Try Now
+            </Link>
+          </motion.div>
           <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
             <Link
               href="/features"
@@ -941,7 +1020,7 @@ export default function LandingPage() {
 
       <main className="flex-grow relative z-10">
         {/* Hero Section */}
-        <section ref={heroRef} className="py-16 px-4 text-center relative overflow-hidden">
+        <section ref={heroRef} className="pt-16 pb-12 px-4 text-center relative overflow-hidden">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -964,10 +1043,21 @@ export default function LandingPage() {
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.3, duration: 0.8 }}
             >
-              Life Cycle Assessment for the{" "}
-              <span className="bg-gradient-to-r from-orange-600 to-purple-600 bg-clip-text text-transparent">
-                Built Environment
-              </span>
+              <AnimatePresence mode="wait">
+                <motion.span
+                  key={currentHeadlineIndex}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -20 }}
+                  transition={{ duration: 0.5 }}
+                  style={{ display: 'block' }}
+                >
+                  {headlines[currentHeadlineIndex].prefix}{" "}
+                  <span className="bg-gradient-to-r from-orange-600 to-purple-600 bg-clip-text text-transparent">
+                    {headlines[currentHeadlineIndex].highlight}
+                  </span>
+                </motion.span>
+              </AnimatePresence>
             </motion.h1>
 
             <motion.p
@@ -976,9 +1066,8 @@ export default function LandingPage() {
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.4, duration: 0.8 }}
             >
-              IfcLCA empowers architects, engineers, and sustainability experts to
-              make data-driven decisions for environmentally optimized structures
-              across the AEC industry using IFC models and Swiss KBOB environmental data.
+              Make data-driven decisions for environmentally optimized structures.
+              Instant analysis using IFC models and Swiss KBOB environmental data.
             </motion.p>
 
             <motion.div
@@ -987,17 +1076,29 @@ export default function LandingPage() {
               transition={{ delay: 0.5, duration: 0.8 }}
               className="flex flex-col sm:flex-row gap-4 justify-center items-center"
             >
-              <Link href="/sign-in?redirect_url=/">
+              <Link href="/try">
                 <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
                   <Button
                     size="lg"
-                    className="bg-gradient-to-r from-orange-600 to-orange-500 hover:from-orange-700 hover:to-orange-600 dark:from-orange-500 dark:to-orange-400 dark:hover:from-orange-600 dark:hover:to-orange-500 text-white shadow-lg shadow-orange-500/25 px-8"
+                    className="bg-gradient-to-r from-orange-600 to-orange-500 hover:from-orange-700 hover:to-orange-600 dark:from-orange-500 dark:to-orange-400 dark:hover:from-orange-600 dark:hover:to-orange-500 text-white shadow-lg shadow-orange-500/25 px-8 py-4 text-lg"
                   >
-                    Start Your Analysis <ArrowRight className="ml-2 h-5 w-5" />
+                    <Zap className="mr-2 h-5 w-5" />
+                    Try Now - No Account Needed
                   </Button>
                 </motion.div>
               </Link>
               <div className="flex gap-3">
+                <Link href="/sign-in?redirect_url=/">
+                  <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+                    <Button
+                      size="lg"
+                      variant="outline"
+                      className="border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800"
+                    >
+                      Sign In <ArrowRight className="ml-2 h-5 w-5" />
+                    </Button>
+                  </motion.div>
+                </Link>
                 <Link href="/documentation">
                   <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
                     <Button
@@ -1005,53 +1106,257 @@ export default function LandingPage() {
                       variant="outline"
                       className="border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800"
                     >
-                      <BookOpen className="mr-2 h-4 w-4" /> Documentation
-                    </Button>
-                  </motion.div>
-                </Link>
-                <Link href="/features">
-                  <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-                    <Button
-                      size="lg"
-                      variant="outline"
-                      className="border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800"
-                    >
-                      <Sparkles className="mr-2 h-4 w-4" /> Features
+                      <BookOpen className="mr-2 h-4 w-4" /> Docs
                     </Button>
                   </motion.div>
                 </Link>
               </div>
             </motion.div>
+
+            {/* Trust indicators */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 0.6, duration: 0.8 }}
+              className="mt-8 flex flex-wrap items-center justify-center gap-6 text-sm text-gray-600 dark:text-gray-400"
+            >
+              <div className="flex items-center gap-2">
+                <Shield className="h-4 w-4 text-green-600 dark:text-green-400" />
+                <span>100% Browser-Based</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <TreePine className="h-4 w-4 text-green-600 dark:text-green-400" />
+                <span>Swiss KBOB Database</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Building2 className="h-4 w-4 text-green-600 dark:text-green-400" />
+                <span>IFC 2x3 & 4 Support</span>
+              </div>
+            </motion.div>
+
+            {/* Directional cue */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1, y: [0, 10, 0] }}
+              transition={{ delay: 0.8, duration: 2, repeat: Infinity }}
+              className="mt-12"
+            >
+              <ArrowDown className="h-6 w-6 text-gray-400 mx-auto" />
+            </motion.div>
           </motion.div>
 
           {/* Animated background elements */}
           <motion.div
-            className="absolute -top-40 -right-40 w-96 h-96 bg-orange-400/20 rounded-full blur-3xl"
+            className="absolute -top-40 -right-40 w-96 h-96 bg-orange-400/10 rounded-full blur-3xl"
             animate={{
-              scale: [1, 1.2, 1],
-              rotate: [0, 180, 360],
+              scale: [1, 1.1, 1],
+              rotate: [0, 90, 180],
+              x: [0, 30, 0],
+              y: [0, -20, 0],
             }}
             transition={{
-              duration: 20,
+              duration: 30,
               repeat: Infinity,
-              ease: "linear",
+              ease: "easeInOut",
             }}
           />
           <motion.div
-            className="absolute -bottom-40 -left-40 w-96 h-96 bg-blue-400/20 rounded-full blur-3xl"
+            className="absolute -bottom-40 -left-40 w-96 h-96 bg-blue-400/10 rounded-full blur-3xl"
             animate={{
-              scale: [1, 1.3, 1],
-              rotate: [360, 180, 0],
+              scale: [1, 1.15, 1],
+              rotate: [180, 90, 0],
+              x: [0, -40, 0],
+              y: [0, 30, 0],
             }}
             transition={{
-              duration: 25,
+              duration: 35,
               repeat: Infinity,
-              ease: "linear",
+              ease: "easeInOut",
             }}
           />
+
+          {/* Subtle gradient fade at bottom */}
+          <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-white dark:from-gray-900 to-transparent pointer-events-none" />
         </section>
 
-        {/* Stats Section */}
+        {/* Try It Now Section - MOVED UP FOR BETTER CONVERSION */}
+        <section className="pt-8 pb-16 px-4 relative overflow-hidden bg-gradient-to-b from-gray-50/50 to-white dark:from-gray-800/30 dark:to-gray-900">
+          <motion.div
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            transition={{ duration: 0.8 }}
+            viewport={{ once: true }}
+            className="max-w-6xl mx-auto relative z-10"
+          >
+            <div className="text-center mb-12">
+              <motion.div
+                initial={{ scale: 0 }}
+                whileInView={{ scale: 1 }}
+                transition={{ type: "spring", stiffness: 100 }}
+                viewport={{ once: true }}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-purple-100 dark:bg-purple-900/30 rounded-full text-purple-700 dark:text-purple-300 text-sm font-medium mb-4"
+              >
+                <Zap className="w-4 h-4" />
+                See It In Action
+              </motion.div>
+              <h2 className="text-4xl font-bold text-gray-800 dark:text-white mb-4">
+                Try IfcLCA Right Now
+              </h2>
+              <p className="text-xl text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
+                No signup. No credit card. Just drag & drop your IFC file below for instant results.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+              {/* Left side - Upload preview */}
+              <motion.div
+                initial={{ opacity: 0, x: -20 }}
+                whileInView={{ opacity: 1, x: 0 }}
+                transition={{ delay: 0.2, duration: 0.8 }}
+                viewport={{ once: true }}
+              >
+                <Card className="relative overflow-hidden group hover:shadow-2xl transition-all duration-300">
+                  <div className="absolute inset-0 bg-gradient-to-br from-orange-400/10 to-purple-400/10 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+                  <CardContent className="p-8 relative">
+                    <motion.div
+                      className={`border-2 border-dashed rounded-lg p-12 text-center relative overflow-hidden cursor-pointer transition-all duration-300 ${isDragging
+                        ? "border-orange-500 bg-orange-50 dark:bg-orange-900/20"
+                        : "border-gray-300 dark:border-gray-600 hover:border-orange-400"
+                        }`}
+                      whileHover={{ scale: 1.02 }}
+                      transition={{ type: "spring", stiffness: 300 }}
+                      onDragOver={handleDragOver}
+                      onDragLeave={handleDragLeave}
+                      onDrop={handleDrop}
+                      onClick={() => fileInputRef.current?.click()}
+                    >
+                      {/* Animated particles */}
+                      {[...Array(6)].map((_, i) => (
+                        <motion.div
+                          key={i}
+                          className="absolute w-2 h-2 bg-orange-400/30 rounded-full"
+                          animate={{
+                            x: [0, Math.random() * 100 - 50],
+                            y: [0, Math.random() * 100 - 50],
+                            scale: [0, 1, 0],
+                          }}
+                          transition={{
+                            duration: 3,
+                            repeat: Infinity,
+                            delay: i * 0.5,
+                            ease: "easeOut",
+                          }}
+                          style={{
+                            left: `${Math.random() * 100}%`,
+                            top: `${Math.random() * 100}%`,
+                          }}
+                        />
+                      ))}
+
+                      <motion.div
+                        animate={{
+                          y: [0, -10, 0],
+                          scale: isDragging ? 1.1 : 1,
+                          rotate: isDragging ? 5 : 0,
+                        }}
+                        transition={{
+                          duration: 3,
+                          repeat: Infinity,
+                          ease: "easeInOut",
+                        }}
+                        className="inline-flex p-4 rounded-full bg-gradient-to-r from-orange-100 to-purple-100 dark:from-orange-900/30 dark:to-purple-900/30 mb-4"
+                      >
+                        <Upload className="h-8 w-8 text-orange-600 dark:text-orange-400" />
+                      </motion.div>
+                      <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-2">
+                        Drop your IFC file here
+                      </h3>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        100% browser-based • No data stored
+                      </p>
+
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept=".ifc"
+                        className="hidden"
+                        onChange={handleFileSelect}
+                      />
+                    </motion.div>
+
+                    <Link href="/try">
+                      <Button className="w-full mt-6 bg-gradient-to-r from-orange-600 to-orange-500 hover:from-orange-700 hover:to-orange-600 text-white">
+                        Or Open Try Page <ArrowRight className="ml-2 h-4 w-4" />
+                      </Button>
+                    </Link>
+                  </CardContent>
+                </Card>
+              </motion.div>
+
+              {/* Right side - Features */}
+              <motion.div
+                initial={{ opacity: 0, x: 20 }}
+                whileInView={{ opacity: 1, x: 0 }}
+                transition={{ delay: 0.4, duration: 0.8 }}
+                viewport={{ once: true }}
+                className="space-y-6"
+              >
+                <div className="grid grid-cols-2 gap-4">
+                  {[
+                    { icon: Zap, label: "~30 seconds", title: "Lightning Fast" },
+                    { icon: Shield, label: "100% Private", title: "Browser-Based" },
+                    { icon: BarChart3, label: "3 Indicators", title: "Full Analysis" },
+                    { icon: TreePine, label: "KBOB Data", title: "Swiss Standards" },
+                  ].map((item, index) => (
+                    <motion.div
+                      key={index}
+                      whileHover={{ scale: 1.05 }}
+                      transition={{ type: "spring", stiffness: 300 }}
+                    >
+                      <Card className="h-full hover:shadow-lg transition-shadow">
+                        <CardContent className="p-4 text-center">
+                          <motion.div
+                            whileHover={{ rotate: 360 }}
+                            transition={{ duration: 0.5 }}
+                            className="inline-flex p-2 rounded-lg bg-gradient-to-r from-orange-100 to-purple-100 dark:from-orange-900/30 dark:to-purple-900/30 mb-2"
+                          >
+                            <item.icon className="h-5 w-5 text-orange-600 dark:text-orange-400" />
+                          </motion.div>
+                          <h4 className="font-semibold text-gray-800 dark:text-white text-sm">
+                            {item.title}
+                          </h4>
+                          <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+                            {item.label}
+                          </p>
+                        </CardContent>
+                      </Card>
+                    </motion.div>
+                  ))}
+                </div>
+
+                <Card className="bg-gradient-to-r from-purple-50 to-blue-50 dark:from-purple-900/20 dark:to-blue-900/20 border-purple-200 dark:border-purple-800">
+                  <CardContent className="p-6">
+                    <div className="flex items-start gap-3">
+                      <Sparkles className="h-5 w-5 text-purple-600 dark:text-purple-400 mt-0.5" />
+                      <div>
+                        <h4 className="font-semibold text-gray-800 dark:text-white mb-1">
+                          What You'll Get Instantly
+                        </h4>
+                        <p className="text-sm text-gray-600 dark:text-gray-300">
+                          • Interactive charts showing GWP, UBP, and PENRE values<br />
+                          • Material-by-material breakdown with environmental impact<br />
+                          • Model statistics including element counts and volumes<br />
+                        </p>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              </motion.div>
+            </div>
+          </motion.div>
+        </section>
+
+        {/* Stats Section - Social Proof */}
         <motion.section
           className="py-16 px-4"
           initial={{ opacity: 0 }}
@@ -1082,35 +1387,8 @@ export default function LandingPage() {
           </div>
         </motion.section>
 
-        {/* Features Section */}
-        <section
-          id="features"
-          className="py-16 px-4 bg-white/80 dark:bg-gray-800/50 backdrop-blur-sm"
-        >
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8 }}
-            viewport={{ once: true }}
-            className="text-center mb-12"
-          >
-            <h2 className="text-4xl font-bold text-gray-800 dark:text-white mb-4">
-              Powerful Features for Sustainable Design
-            </h2>
-            <p className="text-xl text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
-              Everything you need to perform comprehensive life cycle assessments
-            </p>
-          </motion.div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-7xl mx-auto">
-            {features.map((feature, index) => (
-              <FeatureCard key={index} feature={feature} index={index} githubMetrics={githubMetrics} />
-            ))}
-          </div>
-        </section>
-
         {/* How It Works Section */}
-        <section className="py-16 px-4">
+        <section className="py-16 px-4 bg-white/80 dark:bg-gray-800/50 backdrop-blur-sm">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
@@ -1162,8 +1440,8 @@ export default function LandingPage() {
                   >
                     <motion.div
                       className="text-6xl font-bold text-orange-200 dark:text-orange-900 mb-4"
-                      animate={{ opacity: [0.3, 0.6, 0.3] }}
-                      transition={{ duration: 3, repeat: Infinity }}
+                      animate={{ opacity: [0.4, 0.5, 0.4] }}
+                      transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
                     >
                       {item.step}
                     </motion.div>
@@ -1186,71 +1464,32 @@ export default function LandingPage() {
           </motion.div>
         </section>
 
-        {/* Testimonials Section */}
-        {/* <section className="py-16 px-4 bg-gradient-to-r from-orange-50 to-purple-50 dark:from-gray-900 dark:to-gray-800">
+        {/* Features Section */}
+        <section
+          id="features"
+          className="py-16 px-4"
+        >
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8 }}
             viewport={{ once: true }}
-            className="max-w-4xl mx-auto"
+            className="text-center mb-12"
           >
-            <div className="text-center mb-12">
-              <h2 className="text-4xl font-bold text-gray-800 dark:text-white mb-4">
-                Trusted by Industry Leaders
-              </h2>
-              <p className="text-xl text-gray-600 dark:text-gray-300">
-                See what professionals are saying about IfcLCA
-              </p>
-            </div>
-
-            <AnimatePresence mode="wait">
-              <motion.div
-                key={activeTestimonial}
-                initial={{ opacity: 0, x: 20 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: -20 }}
-                transition={{ duration: 0.5 }}
-                className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-sm rounded-2xl p-8 shadow-xl"
-              >
-                <div className="flex items-center mb-4">
-                  {[...Array(testimonials[activeTestimonial].rating)].map((_, i) => (
-                    <Star key={i} className="h-5 w-5 text-yellow-500 fill-current" />
-                  ))}
-                </div>
-                <p className="text-lg text-gray-700 dark:text-gray-300 mb-6 italic">
-                  "{testimonials[activeTestimonial].quote}"
-                </p>
-                <div className="flex items-center">
-                  <div className="w-12 h-12 bg-gradient-to-r from-orange-400 to-purple-400 rounded-full mr-4" />
-                  <div>
-                    <h4 className="font-semibold text-gray-800 dark:text-white">
-                      {testimonials[activeTestimonial].name}
-                    </h4>
-                    <p className="text-sm text-gray-600 dark:text-gray-400">
-                      {testimonials[activeTestimonial].role} at {testimonials[activeTestimonial].company}
-                    </p>
-                  </div>
-                </div>
-              </motion.div>
-            </AnimatePresence>
-
-            <div className="flex justify-center mt-6 gap-2">
-              {testimonials.map((_, index) => (
-                <motion.button
-                  key={index}
-                  onClick={() => setActiveTestimonial(index)}
-                  className={`w-2 h-2 rounded-full transition-all duration-300 ${index === activeTestimonial
-                    ? "w-8 bg-orange-600 dark:bg-orange-400"
-                    : "bg-gray-400 dark:bg-gray-600"
-                    }`}
-                  whileHover={{ scale: 1.2 }}
-                  whileTap={{ scale: 0.9 }}
-                />
-              ))}
-            </div>
+            <h2 className="text-4xl font-bold text-gray-800 dark:text-white mb-4">
+              Powerful Features for Sustainable Design
+            </h2>
+            <p className="text-xl text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
+              Everything you need to perform comprehensive life cycle assessments
+            </p>
           </motion.div>
-        </section> */}
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-7xl mx-auto">
+            {features.map((feature, index) => (
+              <FeatureCard key={index} feature={feature} index={index} githubMetrics={githubMetrics} />
+            ))}
+          </div>
+        </section>
 
         {/* About Section */}
         <section id="about" className="py-16 px-4">
@@ -1341,12 +1580,12 @@ export default function LandingPage() {
                     className="rounded-2xl shadow-2xl"
                   />
                   <motion.div
-                    className="absolute -inset-4 bg-gradient-to-r from-orange-400 to-purple-400 rounded-2xl opacity-20 blur-2xl -z-10"
+                    className="absolute -inset-4 bg-gradient-to-r from-orange-400 to-purple-400 rounded-2xl opacity-10 blur-2xl -z-10"
                     animate={{
-                      scale: [1, 1.05, 1],
+                      scale: [1, 1.02, 1],
                     }}
                     transition={{
-                      duration: 4,
+                      duration: 6,
                       repeat: Infinity,
                       ease: "easeInOut",
                     }}
@@ -1355,10 +1594,10 @@ export default function LandingPage() {
                 <motion.div
                   className="absolute -top-6 -right-6 bg-orange-100 dark:bg-orange-900/30 rounded-xl p-4 shadow-lg"
                   animate={{
-                    y: [0, -10, 0],
+                    y: [0, -5, 0],
                   }}
                   transition={{
-                    duration: 3,
+                    duration: 4,
                     repeat: Infinity,
                     ease: "easeInOut",
                   }}
@@ -1368,13 +1607,13 @@ export default function LandingPage() {
                 <motion.div
                   className="absolute -bottom-6 -left-6 bg-blue-100 dark:bg-blue-900/30 rounded-xl p-4 shadow-lg"
                   animate={{
-                    y: [0, 10, 0],
+                    y: [0, 5, 0],
                   }}
                   transition={{
-                    duration: 3,
+                    duration: 4,
                     repeat: Infinity,
                     ease: "easeInOut",
-                    delay: 1.5,
+                    delay: 2,
                   }}
                 >
                   <TrendingUp className="h-8 w-8 text-blue-600 dark:text-blue-400" />
@@ -1385,55 +1624,81 @@ export default function LandingPage() {
         </section>
 
         {/* CTA Section */}
-        <section className="py-16 px-4">
+        <section className="py-20 px-4 relative overflow-hidden">
           <motion.div
-            initial={{ opacity: 0, scale: 0.9 }}
-            whileInView={{ opacity: 1, scale: 1 }}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8 }}
             viewport={{ once: true }}
-            className="max-w-4xl mx-auto"
+            className="max-w-4xl mx-auto text-center relative z-10"
           >
-            <div className="bg-gradient-to-r from-orange-600 to-purple-600 rounded-3xl p-12 text-center text-white relative overflow-hidden">
-              <motion.div
-                className="absolute inset-0 bg-white/10"
-                animate={{
-                  backgroundImage: [
-                    "radial-gradient(circle at 20% 50%, transparent 0%, transparent 50%, white 50%, white 60%, transparent 60%)",
-                    "radial-gradient(circle at 80% 50%, transparent 0%, transparent 50%, white 50%, white 60%, transparent 60%)",
-                    "radial-gradient(circle at 20% 50%, transparent 0%, transparent 50%, white 50%, white 60%, transparent 60%)",
-                  ],
-                }}
-                transition={{
-                  duration: 4,
-                  repeat: Infinity,
-                  ease: "easeInOut",
-                }}
-              />
-              <div className="relative z-10">
-                <h2 className="text-4xl font-bold mb-4">
-                  Ready to Transform Your Life Cycle Analysis?
-                </h2>
-                <p className="text-xl mb-8 opacity-90">
-                  Join other professionals using IfcLCA for sustainable design and construction
-                </p>
-                <motion.div
-                  whileHover={{ scale: 1.05 }}
-                  whileTap={{ scale: 0.95 }}
-                  className="inline-block"
-                >
-                  <Link href="/sign-in?redirect_url=/">
-                    <Button
-                      size="lg"
-                      className="bg-white text-orange-600 hover:bg-gray-100 shadow-xl px-8 py-6 text-lg"
-                    >
-                      Start Now for Free
-                      <ArrowRight className="ml-2 h-5 w-5" />
-                    </Button>
-                  </Link>
+            <h2 className="text-4xl md:text-5xl font-bold text-gray-800 dark:text-white mb-6">
+              Start Your Environmental Analysis Today
+            </h2>
+            <p className="text-xl text-gray-600 dark:text-gray-300 mb-8 max-w-2xl mx-auto">
+              Join leading architects and engineers using IfcLCA to create more sustainable buildings.
+              Free to try, powerful when you need it.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/try">
+                <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+                  <Button
+                    size="lg"
+                    className="bg-gradient-to-r from-orange-600 to-orange-500 hover:from-orange-700 hover:to-orange-600 text-white shadow-lg shadow-orange-500/25 px-8 py-4 text-lg"
+                  >
+                    <Zap className="mr-2 h-5 w-5" />
+                    Try Now - No Account Needed
+                  </Button>
                 </motion.div>
-              </div>
+              </Link>
+              <Link href="/sign-up">
+                <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+                  <Button
+                    size="lg"
+                    variant="outline"
+                    className="border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800"
+                  >
+                    Create Free Account
+                  </Button>
+                </motion.div>
+              </Link>
             </div>
+            <motion.p
+              className="mt-6 text-sm text-gray-500 dark:text-gray-400"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 0.5 }}
+            >
+              <Shield className="inline-block h-4 w-4 mr-1" />
+              100% browser-based • Your data never leaves your device
+            </motion.p>
           </motion.div>
+
+          {/* Animated background gradients */}
+          <motion.div
+            className="absolute -top-40 -right-40 w-96 h-96 bg-gradient-to-br from-orange-400/10 to-purple-400/10 rounded-full blur-3xl"
+            animate={{
+              scale: [1, 1.1, 1],
+              rotate: [0, 60, 120],
+            }}
+            transition={{
+              duration: 30,
+              repeat: Infinity,
+              ease: "easeInOut",
+            }}
+          />
+          <motion.div
+            className="absolute -bottom-40 -left-40 w-96 h-96 bg-gradient-to-tr from-blue-400/10 to-green-400/10 rounded-full blur-3xl"
+            animate={{
+              scale: [1, 1.15, 1],
+              rotate: [120, 60, 0],
+            }}
+            transition={{
+              duration: 35,
+              repeat: Infinity,
+              ease: "easeInOut",
+            }}
+          />
         </section>
       </main>
 

--- a/src/components/navigation-header.tsx
+++ b/src/components/navigation-header.tsx
@@ -5,11 +5,13 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import Image from "next/image";
-import { Menu, Sun, Moon } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { Menu, Sun, Moon, Zap } from "lucide-react";
 
 export default function NavigationHeader() {
     const [isDarkMode, setIsDarkMode] = useState(false);
     const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const pathname = usePathname();
 
     useEffect(() => {
         const root = document.documentElement;
@@ -29,6 +31,28 @@ export default function NavigationHeader() {
 
     const toggleMenu = () => {
         setIsMenuOpen(!isMenuOpen);
+    };
+
+    const isActive = (path: string) => {
+        return pathname === path;
+    };
+
+    const getLinkClasses = (path: string, isHighlighted: boolean = false) => {
+        const isCurrentPage = isActive(path);
+
+        if (isHighlighted) {
+            // Try Now link styling
+            return `px-4 py-2 text-sm font-medium transition-colors flex items-center gap-1 ${isCurrentPage
+                    ? "text-orange-700 dark:text-orange-300"
+                    : "text-orange-600 hover:text-orange-700 dark:text-orange-400 dark:hover:text-orange-300"
+                }`;
+        }
+
+        // Regular link styling
+        return `px-4 py-2 text-sm transition-colors ${isCurrentPage
+                ? "text-gray-900 font-medium dark:text-white"
+                : "text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white"
+            }`;
     };
 
     return (
@@ -67,8 +91,17 @@ export default function NavigationHeader() {
                     <nav className="hidden md:flex items-center space-x-4">
                         <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
                             <Link
+                                href="/try"
+                                className={getLinkClasses("/try", true)}
+                            >
+                                <Zap className="h-3.5 w-3.5" />
+                                Try Now
+                            </Link>
+                        </motion.div>
+                        <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+                            <Link
                                 href="/features"
-                                className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white transition-colors"
+                                className={getLinkClasses("/features")}
                             >
                                 Features
                             </Link>
@@ -76,7 +109,7 @@ export default function NavigationHeader() {
                         <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
                             <Link
                                 href="/documentation"
-                                className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white transition-colors"
+                                className={getLinkClasses("/documentation")}
                             >
                                 Documentation
                             </Link>
@@ -84,7 +117,7 @@ export default function NavigationHeader() {
                         <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
                             <Link
                                 href="/sign-in?redirect_url=/"
-                                className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white transition-colors"
+                                className={getLinkClasses("/sign-in")}
                             >
                                 Login
                             </Link>
@@ -131,22 +164,33 @@ export default function NavigationHeader() {
                     >
                         <nav className="flex flex-col space-y-4">
                             <Link
+                                href="/try"
+                                className={`${getLinkClasses("/try", true)} ${isActive("/try") ? "bg-orange-50 dark:bg-orange-900/20 rounded-lg px-4 py-2" : ""
+                                    }`}
+                                onClick={toggleMenu}
+                            >
+                                <Zap className="h-3.5 w-3.5" />
+                                Try Now
+                            </Link>
+                            <Link
                                 href="/features"
-                                className="text-sm text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white"
+                                className={`${getLinkClasses("/features")} ${isActive("/features") ? "bg-gray-100 dark:bg-gray-700 rounded-lg px-4 py-2" : ""
+                                    }`}
                                 onClick={toggleMenu}
                             >
                                 Features
                             </Link>
                             <Link
                                 href="/documentation"
-                                className="text-sm text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white"
+                                className={`${getLinkClasses("/documentation")} ${isActive("/documentation") ? "bg-gray-100 dark:bg-gray-700 rounded-lg px-4 py-2" : ""
+                                    }`}
                                 onClick={toggleMenu}
                             >
                                 Documentation
                             </Link>
                             <Link
                                 href="/sign-in?redirect_url=/"
-                                className="text-sm text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white"
+                                className={getLinkClasses("/sign-in")}
                                 onClick={toggleMenu}
                             >
                                 Login

--- a/src/components/try-now-page.tsx
+++ b/src/components/try-now-page.tsx
@@ -1,0 +1,1076 @@
+"use client";
+
+import { useState, useRef, useCallback, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { parseIfcWithWasm } from "@/lib/services/ifc-wasm-parser";
+import { DataTable } from "@/components/data-table";
+import { elementsColumns } from "@/components/elements-columns";
+import { materialsColumns } from "@/components/materials-columns";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import Fuse from "fuse.js";
+import Link from "next/link";
+import { useProjectEmissions } from "@/hooks/use-project-emissions";
+import { EmissionsSummaryCard } from "@/components/emissions-summary-card";
+import NavigationHeader from "@/components/navigation-header";
+import { fileTransferService } from "@/lib/file-transfer";
+import {
+  Upload,
+  FileUp,
+  CheckCircle,
+  AlertCircle,
+  Loader2,
+  BarChart3,
+  TreePine,
+  Zap,
+  Database,
+  Sparkles,
+  ArrowRight,
+  RefreshCw,
+  Download,
+  Eye,
+  X,
+  Building2,
+  Layers,
+  Square,
+  Columns3,
+  Minus,
+  Cuboid,
+  Package,
+} from "lucide-react";
+import {
+  Bar,
+  BarChart,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Cell,
+  PieChart,
+  Pie,
+  Legend,
+} from "recharts";
+
+interface KBOBMaterial {
+  Name: string;
+  GWP: number;
+  UBP: number;
+  PENRE: number;
+  "kg/unit"?: number;
+  "min density"?: number;
+  "max density"?: number;
+}
+
+interface MaterialEntry {
+  _id: string;
+  name: string;
+  material: {
+    name: string;
+    density?: number;
+    kbobMatch?: KBOBMaterial;
+  };
+  volume: number;
+  emissions: {
+    gwp: number;
+    ubp: number;
+    penre: number;
+  };
+}
+
+interface ElementEntry {
+  _id: string;
+  name: string;
+  type: string;
+  totalVolume: number;
+  materials: {
+    material: {
+      name: string;
+      density?: number;
+      kbobMatch?: KBOBMaterial;
+    };
+    volume: number;
+  }[];
+  emissions: {
+    gwp: number;
+    ubp: number;
+    penre: number;
+  };
+  isExternal: boolean;
+  loadBearing: boolean;
+}
+
+// Processing stages for progress tracking
+const PROCESSING_STAGES = [
+  { id: "upload", label: "Uploading file", icon: Upload },
+  { id: "parse", label: "Parsing IFC data", icon: FileUp },
+  { id: "match", label: "Matching materials", icon: Database },
+  { id: "calculate", label: "Calculating emissions", icon: BarChart3 },
+  { id: "complete", label: "Analysis complete", icon: CheckCircle },
+];
+
+// Dynamic insights that rotate during processing
+const PROCESSING_INSIGHTS = [
+  "Analyzing building geometry...",
+  "Identifying structural elements...",
+  "Measuring material volumes...",
+  "Checking wall assemblies...",
+  "Evaluating slab compositions...",
+  "Processing column data...",
+  "Calculating environmental impact...",
+  "Optimizing data structures...",
+  "Validating IFC relationships...",
+  "Extracting quantity data...",
+];
+
+export default function TryNowPage() {
+  const [materials, setMaterials] = useState<MaterialEntry[]>([]);
+  const [elements, setElements] = useState<ElementEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [currentStage, setCurrentStage] = useState(0);
+  const [completedStages, setCompletedStages] = useState<number[]>([]);
+  const [fileName, setFileName] = useState<string>("");
+  const [fileSize, setFileSize] = useState<string>("");
+  const [error, setError] = useState<string>("");
+  const [isDragging, setIsDragging] = useState(false);
+  const [selectedView, setSelectedView] = useState<"chart" | "table">("chart");
+  const [selectedMetric, setSelectedMetric] = useState<"gwp" | "ubp" | "penre">("gwp");
+  const [processingInsight, setProcessingInsight] = useState("");
+  const [modelStats, setModelStats] = useState<{
+    totalElements: number;
+    wallCount: number;
+    slabCount: number;
+    columnCount: number;
+    beamCount: number;
+    totalVolume: number;
+    uniqueMaterials: number;
+  } | null>(null);
+
+  const kbobDataRef = useRef<KBOBMaterial[] | null>(null);
+  const fuseRef = useRef<Fuse<KBOBMaterial> | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const projectForEmissions = {
+    elements: elements.map((el) => ({
+      materials: el.materials.map((m) => ({
+        volume: m.volume,
+        material: {
+          density: m.material.density,
+          kbobMatch: m.material.kbobMatch,
+        },
+      })),
+    })),
+  };
+
+  const { totals } = useProjectEmissions(projectForEmissions);
+
+  // Check for pending file on mount
+  useEffect(() => {
+    const pendingFile = fileTransferService.getPendingFile();
+    if (pendingFile) {
+      // Automatically process the file
+      handleFile(pendingFile);
+    }
+  }, []);
+
+  const findBestMatch = (name: string): KBOBMaterial | undefined => {
+    const kbobData = kbobDataRef.current;
+    if (!kbobData) return undefined;
+    const lower = name.trim().toLowerCase();
+    const exact = kbobData.find((m) => m.Name.trim().toLowerCase() === lower);
+    if (exact) return exact;
+    if (!fuseRef.current) {
+      fuseRef.current = new Fuse(kbobData, {
+        keys: ["Name"],
+        includeScore: true,
+        threshold: 1,
+      });
+    }
+    const results = fuseRef.current.search(name);
+    return results.length > 0 ? results[0].item : undefined;
+  };
+
+  const calcDensity = (m?: KBOBMaterial) => {
+    if (!m) return undefined;
+    if (typeof m["kg/unit"] === "number") return m["kg/unit"];
+    if (
+      typeof m["min density"] === "number" &&
+      typeof m["max density"] === "number"
+    ) {
+      return (m["min density"] + m["max density"]) / 2;
+    }
+    return undefined;
+  };
+
+  const formatFileSize = (bytes: number): string => {
+    if (bytes === 0) return "0 Bytes";
+    const k = 1024;
+    const sizes = ["Bytes", "KB", "MB", "GB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
+  };
+
+  const formatValue = (value: number): string => {
+    const absValue = Math.abs(value);
+
+    if (absValue >= 1_000_000_000) {
+      return `${(value / 1_000_000_000).toFixed(1)}B`;
+    } else if (absValue >= 1_000_000) {
+      return `${(value / 1_000_000).toFixed(1)}M`;
+    } else if (absValue >= 1_000) {
+      return `${(value / 1_000).toFixed(1)}k`;
+    }
+    return value.toFixed(0);
+  };
+
+  const formatAxisValue = (value: number): string => {
+    const absValue = Math.abs(value);
+
+    if (absValue >= 1_000_000_000) {
+      return `${(value / 1_000_000_000).toFixed(0)}B`;
+    } else if (absValue >= 1_000_000) {
+      return `${(value / 1_000_000).toFixed(0)}M`;
+    } else if (absValue >= 10_000) {
+      return `${(value / 1_000).toFixed(0)}k`;
+    } else if (absValue >= 1_000) {
+      return `${(value / 1_000).toFixed(1)}k`;
+    }
+    return value.toFixed(0);
+  };
+
+  const handleFile = async (file: File) => {
+    setLoading(true);
+    setError("");
+    setFileName(file.name);
+    setFileSize(formatFileSize(file.size));
+    setCurrentStage(0);
+    setCompletedStages([]);
+
+    // Start insight rotation
+    const insightInterval = setInterval(() => {
+      setProcessingInsight(PROCESSING_INSIGHTS[Math.floor(Math.random() * PROCESSING_INSIGHTS.length)]);
+    }, 800);
+
+    try {
+      // Process file with real-time stage updates
+      await processFileWithProgress(file);
+
+    } catch (err) {
+      console.error(err);
+      setError("Failed to process the IFC file. Please ensure it contains valid data.");
+    } finally {
+      clearInterval(insightInterval);
+      setProcessingInsight("");
+      setLoading(false);
+    }
+  };
+
+  // Update stage with minimum display time for visibility
+  const updateStage = async (stage: number) => {
+    setCurrentStage(stage);
+
+    // Ensure each stage is visible for at least 200ms
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    // Mark stage as completed
+    setCompletedStages(prev => [...prev, stage]);
+  };
+
+  // Process file with real-time progress updates
+  const processFileWithProgress = async (file: File) => {
+    // Stage 0: Upload (instant, but show it)
+    await updateStage(0);
+
+    // Stage 1: Parse IFC
+    await updateStage(1);
+
+    // Load KBOB data if needed
+    if (!kbobDataRef.current) {
+      const res = await fetch("/api/kbob");
+      kbobDataRef.current = await res.json();
+    }
+
+    // Parse IFC
+    const { elements: parsed } = await parseIfcWithWasm(file);
+
+    // Stage 2: Match materials
+    await updateStage(2);
+
+    // Calculate model statistics
+    const stats = {
+      totalElements: parsed.length,
+      wallCount: parsed.filter(el => el.type?.toLowerCase().includes('wall')).length,
+      slabCount: parsed.filter(el => el.type?.toLowerCase().includes('slab')).length,
+      columnCount: parsed.filter(el => el.type?.toLowerCase().includes('column')).length,
+      beamCount: parsed.filter(el => el.type?.toLowerCase().includes('beam')).length,
+      totalVolume: 0,
+      uniqueMaterials: 0,
+    };
+
+    // Collect all unique material names
+    const uniqueMaterialNames = new Set<string>();
+    parsed.forEach((el) => {
+      if (el.materials?.length) {
+        el.materials.forEach((name) => uniqueMaterialNames.add(name));
+      }
+      if (el.material_volumes) {
+        Object.keys(el.material_volumes).forEach((name) => uniqueMaterialNames.add(name));
+      }
+    });
+
+    // Match each unique material name only once
+    const materialMatchMap = new Map<string, { match?: KBOBMaterial; density?: number }>();
+    uniqueMaterialNames.forEach((name) => {
+      const match = findBestMatch(name);
+      const density = calcDensity(match);
+      materialMatchMap.set(name, { match, density });
+    });
+
+    // Stage 3: Calculate emissions
+    await updateStage(3);
+
+    // Process elements and calculate emissions
+    const els: ElementEntry[] = parsed.map((el) => {
+      const mats: ElementEntry["materials"] = [];
+      const baseVolume = el.volume || 0;
+
+      if (el.materials?.length) {
+        el.materials.forEach((name) => {
+          const { match, density } = materialMatchMap.get(name) || {};
+          mats.push({
+            material: { name, density, kbobMatch: match },
+            volume: baseVolume / el.materials!.length,
+          });
+        });
+      }
+
+      if (el.material_volumes) {
+        Object.entries(el.material_volumes).forEach(([name, data]) => {
+          const { match, density } = materialMatchMap.get(name) || {};
+          mats.push({
+            material: { name, density, kbobMatch: match },
+            volume: (data as any).volume,
+          });
+        });
+      }
+
+      const emissions = mats.reduce(
+        (acc, m) => {
+          if (m.material.kbobMatch && m.material.density) {
+            acc.gwp +=
+              m.volume *
+              m.material.density *
+              m.material.kbobMatch.GWP;
+            acc.ubp +=
+              m.volume *
+              m.material.density *
+              m.material.kbobMatch.UBP;
+            acc.penre +=
+              m.volume *
+              m.material.density *
+              m.material.kbobMatch.PENRE;
+          }
+          return acc;
+        },
+        { gwp: 0, ubp: 0, penre: 0 }
+      );
+
+      return {
+        _id: el.id,
+        name: el.object_type || el.type,
+        type: el.type,
+        totalVolume: baseVolume,
+        materials: mats,
+        emissions,
+        isExternal: el.properties?.isExternal || false,
+        loadBearing: el.properties?.loadBearing || false,
+      };
+    });
+
+    // Aggregate materials
+    const matMap = new Map<string, MaterialEntry>();
+    els.forEach((el) => {
+      el.materials.forEach((m) => {
+        const key = m.material.name.toLowerCase();
+        const existing = matMap.get(key) || {
+          _id: key,
+          name: m.material.name,
+          material: {
+            name: m.material.name,
+            density: m.material.density,
+            kbobMatch: m.material.kbobMatch,
+          },
+          volume: 0,
+          emissions: { gwp: 0, ubp: 0, penre: 0 },
+        };
+        existing.volume += m.volume;
+        if (m.material.kbobMatch && m.material.density) {
+          existing.emissions.gwp +=
+            m.volume * m.material.density * m.material.kbobMatch.GWP;
+          existing.emissions.ubp +=
+            m.volume * m.material.density * m.material.kbobMatch.UBP;
+          existing.emissions.penre +=
+            m.volume * m.material.density * m.material.kbobMatch.PENRE;
+        }
+        matMap.set(key, existing);
+      });
+    });
+
+    // Set final results
+    setElements(els);
+    setMaterials(Array.from(matMap.values()));
+
+    // Update statistics
+    stats.totalVolume = els.reduce((sum, el) => sum + el.totalVolume, 0);
+    stats.uniqueMaterials = matMap.size;
+    setModelStats(stats);
+
+    // Stage 4: Complete
+    await updateStage(4);
+  };
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  }, []);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+
+    const file = e.dataTransfer.files[0];
+    if (file && file.name.toLowerCase().endsWith('.ifc')) {
+      handleFile(file);
+    } else {
+      setError("Please upload a valid IFC file");
+    }
+  }, []);
+
+  const resetAnalysis = () => {
+    setMaterials([]);
+    setElements([]);
+    setFileName("");
+    setFileSize("");
+    setError("");
+    setCurrentStage(0);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  // Chart data preparation
+  const chartData = materials
+    .filter(m => m.emissions[selectedMetric] > 0)
+    .sort((a, b) => b.emissions[selectedMetric] - a.emissions[selectedMetric])
+    .slice(0, 10)
+    .map(m => ({
+      name: m.name,
+      value: m.emissions[selectedMetric],
+      volume: m.volume,
+    }));
+
+  const pieData = materials
+    .filter(m => m.emissions[selectedMetric] > 0)
+    .sort((a, b) => b.emissions[selectedMetric] - a.emissions[selectedMetric])
+    .slice(0, 5)
+    .map(m => ({
+      name: m.name,
+      value: m.emissions[selectedMetric],
+    }));
+
+  const getMetricLabel = (metric: string) => {
+    switch (metric) {
+      case "gwp": return "GWP (kg CO₂-eq)";
+      case "ubp": return "UBP (Environmental Points)";
+      case "penre": return "PEnr (kWh oil-eq)";
+      default: return "";
+    }
+  };
+
+  const COLORS = [
+    "#ff6b35", "#f7931e", "#fdc830", "#95c11f", "#39b54a",
+    "#00a79d", "#0093d0", "#2e3192", "#662d91", "#ec008c"
+  ];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-blue-50 to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
+      <NavigationHeader />
+
+      <div className="container mx-auto p-6 space-y-8">
+        {/* Header */}
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="text-center space-y-4"
+        >
+          <div className="inline-flex items-center gap-2 px-4 py-2 bg-orange-100 dark:bg-orange-900/30 rounded-full text-orange-700 dark:text-orange-300 text-sm font-medium">
+            <Zap className="w-4 h-4" />
+            Try IfcLCA Without an Account
+          </div>
+          <h1 className="text-4xl md:text-5xl font-bold text-gray-800 dark:text-white">
+            Experience Instant{" "}
+            <span className="bg-gradient-to-r from-orange-600 to-purple-600 bg-clip-text text-transparent">
+              Environmental Analysis
+            </span>
+          </h1>
+          <p className="text-xl text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
+            Upload your IFC file and see the power of IfcLCA. Your data is processed locally in your browser - nothing is stored.
+          </p>
+        </motion.div>
+
+        {/* Main Content */}
+        <AnimatePresence mode="wait">
+          {!loading && elements.length === 0 ? (
+            // Upload Interface
+            <motion.div
+              key="upload"
+              initial={{ opacity: 0, scale: 0.9 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.9 }}
+              transition={{ duration: 0.3 }}
+            >
+              <Card className="max-w-3xl mx-auto overflow-hidden">
+                <CardContent className="p-0">
+                  <motion.div
+                    className={`relative p-12 border-2 border-dashed rounded-lg transition-all duration-300 ${isDragging
+                      ? "border-orange-500 bg-orange-50 dark:bg-orange-900/20"
+                      : "border-gray-300 dark:border-gray-600 hover:border-orange-400"
+                      }`}
+                    onDragOver={handleDragOver}
+                    onDragLeave={handleDragLeave}
+                    onDrop={handleDrop}
+                  >
+                    {/* Animated background pattern */}
+                    <div className="absolute inset-0 opacity-5">
+                      <div className="absolute inset-0 bg-grid-pattern" />
+                    </div>
+
+                    <div className="relative z-10 text-center space-y-6">
+                      <motion.div
+                        animate={{
+                          scale: isDragging ? 1.1 : 1,
+                          rotate: isDragging ? 5 : 0,
+                        }}
+                        transition={{ type: "spring", stiffness: 300 }}
+                        className="inline-flex p-6 rounded-full bg-gradient-to-r from-orange-100 to-purple-100 dark:from-orange-900/30 dark:to-purple-900/30"
+                      >
+                        <Upload className="h-12 w-12 text-orange-600 dark:text-orange-400" />
+                      </motion.div>
+
+                      <div className="space-y-2">
+                        <h3 className="text-2xl font-semibold text-gray-800 dark:text-white">
+                          Drop your IFC file here
+                        </h3>
+                        <p className="text-gray-600 dark:text-gray-300">
+                          or click to browse
+                        </p>
+                      </div>
+
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept=".ifc"
+                        className="hidden"
+                        onChange={(e) => {
+                          const file = e.target.files?.[0];
+                          if (file) handleFile(file);
+                        }}
+                      />
+
+                      <Button
+                        size="lg"
+                        onClick={() => fileInputRef.current?.click()}
+                        className="bg-gradient-to-r from-orange-600 to-orange-500 hover:from-orange-700 hover:to-orange-600 text-white shadow-lg"
+                      >
+                        Select IFC File
+                        <ArrowRight className="ml-2 h-5 w-5" />
+                      </Button>
+
+                      <div className="flex items-center justify-center gap-6 pt-4 text-sm text-gray-500 dark:text-gray-400">
+                        <div className="flex items-center gap-2">
+                          <CheckCircle className="h-4 w-4 text-green-500" />
+                          <span>100% Browser-based</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <CheckCircle className="h-4 w-4 text-green-500" />
+                          <span>No data stored</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <CheckCircle className="h-4 w-4 text-green-500" />
+                          <span>Instant results</span>
+                        </div>
+                      </div>
+                    </div>
+                  </motion.div>
+
+                  {error && (
+                    <motion.div
+                      initial={{ opacity: 0, y: -10 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      className="p-4 bg-red-50 dark:bg-red-900/20 border-t border-red-200 dark:border-red-800"
+                    >
+                      <div className="flex items-center gap-2 text-red-600 dark:text-red-400">
+                        <AlertCircle className="h-5 w-5" />
+                        <span>{error}</span>
+                      </div>
+                    </motion.div>
+                  )}
+                </CardContent>
+              </Card>
+
+              {/* Feature highlights */}
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-12 max-w-4xl mx-auto">
+                {[
+                  {
+                    icon: TreePine,
+                    title: "Swiss KBOB Data",
+                    description: "Access 300+ construction materials from lcadata.ch with precise GWP, UBP, and PEnr values based on Swiss standards",
+                  },
+                  {
+                    icon: Sparkles,
+                    title: "Smart Matching",
+                    description: "Fuzzy string matching automatically links your IFC material names to KBOB entries, handling variations and typos intelligently",
+                  },
+                  {
+                    icon: BarChart3,
+                    title: "Visual Analytics",
+                    description: "Interactive bar and pie charts with formatted values, material breakdowns by volume, and exportable results for reports",
+                  },
+                ].map((feature, index) => (
+                  <motion.div
+                    key={index}
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: index * 0.1 }}
+                  >
+                    <Card className="h-full hover:shadow-lg transition-shadow">
+                      <CardContent className="p-6 text-center space-y-3">
+                        <div className="inline-flex p-3 rounded-xl bg-gradient-to-r from-orange-100 to-purple-100 dark:from-orange-900/30 dark:to-purple-900/30">
+                          <feature.icon className="h-6 w-6 text-orange-600 dark:text-orange-400" />
+                        </div>
+                        <h3 className="font-semibold text-gray-800 dark:text-white">
+                          {feature.title}
+                        </h3>
+                        <p className="text-sm text-gray-600 dark:text-gray-300">
+                          {feature.description}
+                        </p>
+                      </CardContent>
+                    </Card>
+                  </motion.div>
+                ))}
+              </div>
+            </motion.div>
+          ) : loading ? (
+            // Processing Animation
+            <motion.div
+              key="processing"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="max-w-2xl mx-auto"
+            >
+              <Card>
+                <CardContent className="p-8 space-y-6">
+                  <div className="text-center space-y-4">
+                    <motion.div
+                      animate={{
+                        rotate: 360,
+                      }}
+                      transition={{
+                        duration: 2,
+                        repeat: Infinity,
+                        ease: "linear",
+                      }}
+                      className="inline-flex p-4 rounded-full bg-gradient-to-r from-orange-100 to-purple-100 dark:from-orange-900/30 dark:to-purple-900/30"
+                    >
+                      <Loader2 className="h-8 w-8 text-orange-600 dark:text-orange-400" />
+                    </motion.div>
+
+                    <div>
+                      <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-2">
+                        Processing {fileName}
+                      </h3>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        {fileSize}
+                      </p>
+                    </div>
+                  </div>
+
+                  {/* Dynamic insight */}
+                  {processingInsight && (
+                    <motion.div
+                      key={processingInsight}
+                      initial={{ opacity: 0, y: -10 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: 10 }}
+                      className="text-center"
+                    >
+                      <p className="text-sm text-gray-600 dark:text-gray-400 italic">
+                        {processingInsight}
+                      </p>
+                    </motion.div>
+                  )}
+
+                  {/* Progress stages */}
+                  <div className="space-y-3">
+                    {PROCESSING_STAGES.map((stage, index) => {
+                      const Icon = stage.icon;
+                      const isActive = index === currentStage;
+                      const isComplete = completedStages.includes(index);
+
+                      return (
+                        <motion.div
+                          key={stage.id}
+                          initial={{ opacity: 0, x: -20 }}
+                          animate={{ opacity: 1, x: 0 }}
+                          transition={{ delay: index * 0.1 }}
+                          className={`flex items-center gap-3 p-3 rounded-lg transition-all ${isActive
+                            ? "bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800"
+                            : isComplete
+                              ? "bg-green-50 dark:bg-green-900/20"
+                              : "bg-gray-50 dark:bg-gray-800/50"
+                            }`}
+                        >
+                          <div className={`p-2 rounded-full ${isActive
+                            ? "bg-orange-100 dark:bg-orange-900/30"
+                            : isComplete
+                              ? "bg-green-100 dark:bg-green-900/30"
+                              : "bg-gray-100 dark:bg-gray-800"
+                            }`}>
+                            <Icon className={`h-4 w-4 ${isActive
+                              ? "text-orange-600 dark:text-orange-400"
+                              : isComplete
+                                ? "text-green-600 dark:text-green-400"
+                                : "text-gray-400 dark:text-gray-600"
+                              }`} />
+                          </div>
+                          <span className={`text-sm font-medium ${isActive
+                            ? "text-orange-700 dark:text-orange-300"
+                            : isComplete
+                              ? "text-green-700 dark:text-green-300"
+                              : "text-gray-500 dark:text-gray-400"
+                            }`}>
+                            {stage.label}
+                          </span>
+                          {isComplete && (
+                            <CheckCircle className="h-4 w-4 text-green-500 ml-auto" />
+                          )}
+                          {isActive && (
+                            <motion.div
+                              animate={{ scale: [1, 1.2, 1] }}
+                              transition={{ repeat: Infinity, duration: 1.5 }}
+                              className="ml-auto"
+                            >
+                              <div className="w-2 h-2 bg-orange-500 rounded-full" />
+                            </motion.div>
+                          )}
+                        </motion.div>
+                      );
+                    })}
+                  </div>
+                </CardContent>
+              </Card>
+            </motion.div>
+          ) : (
+            // Results View
+            <motion.div
+              key="results"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="space-y-6"
+            >
+              {/* File info and actions */}
+              <Card>
+                <CardContent className="p-4">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-4">
+                      <div className="p-2 rounded-lg bg-green-100 dark:bg-green-900/30">
+                        <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400" />
+                      </div>
+                      <div>
+                        <h3 className="font-semibold text-gray-800 dark:text-white">
+                          {fileName}
+                        </h3>
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
+                          Analysis complete • {fileSize} • {modelStats?.totalElements} elements
+                        </p>
+                      </div>
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={resetAnalysis}
+                      className="flex items-center gap-2"
+                    >
+                      <RefreshCw className="h-4 w-4" />
+                      New Analysis
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Model Statistics - NEW */}
+              {modelStats && (
+                <motion.div
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-4"
+                >
+                  {[
+                    { label: "Total Elements", value: modelStats.totalElements, icon: Building2 },
+                    { label: "Walls", value: modelStats.wallCount, icon: Square },
+                    { label: "Slabs", value: modelStats.slabCount, icon: Layers },
+                    { label: "Columns", value: modelStats.columnCount, icon: Columns3 },
+                    { label: "Beams", value: modelStats.beamCount, icon: Minus },
+                    { label: "Total Volume", value: modelStats.totalVolume, unit: "m³", icon: Cuboid },
+                    { label: "Materials", value: modelStats.uniqueMaterials, icon: Package },
+                  ].map((stat, index) => (
+                    <motion.div
+                      key={stat.label}
+                      initial={{ opacity: 0, scale: 0.9 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      transition={{ delay: index * 0.05 }}
+                    >
+                      <Card className="hover:shadow-md transition-shadow">
+                        <CardContent className="p-4 text-center">
+                          <stat.icon className="h-5 w-5 mx-auto mb-2 text-gray-400" />
+                          <p className="text-2xl font-bold text-gray-800 dark:text-white">
+                            {formatValue(stat.value)}{stat.unit ? ` ${stat.unit}` : ''}
+                          </p>
+                          <p className="text-xs text-gray-600 dark:text-gray-400">
+                            {stat.label}
+                          </p>
+                        </CardContent>
+                      </Card>
+                    </motion.div>
+                  ))}
+                </motion.div>
+              )}
+
+              {/* Emissions Summary */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Environmental Impact Summary</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <EmissionsSummaryCard project={projectForEmissions} />
+                </CardContent>
+              </Card>
+
+              {/* Visualization Tabs */}
+              <Card>
+                <CardHeader>
+                  <div className="flex items-center justify-between">
+                    <CardTitle>Material Analysis</CardTitle>
+                    <Tabs value={selectedView} onValueChange={(v) => setSelectedView(v as any)}>
+                      <TabsList>
+                        <TabsTrigger value="chart">
+                          <BarChart3 className="h-4 w-4 mr-2" />
+                          Charts
+                        </TabsTrigger>
+                        <TabsTrigger value="table">
+                          <Eye className="h-4 w-4 mr-2" />
+                          Tables
+                        </TabsTrigger>
+                      </TabsList>
+                    </Tabs>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  {selectedView === "chart" ? (
+                    <div className="space-y-6">
+                      {/* Metric selector */}
+                      <div className="flex justify-center">
+                        <Tabs value={selectedMetric} onValueChange={(v) => setSelectedMetric(v as any)}>
+                          <TabsList>
+                            <TabsTrigger value="gwp">GWP</TabsTrigger>
+                            <TabsTrigger value="ubp">UBP</TabsTrigger>
+                            <TabsTrigger value="penre">PEnr</TabsTrigger>
+                          </TabsList>
+                        </Tabs>
+                      </div>
+
+                      {/* Charts */}
+                      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                        {/* Bar Chart */}
+                        <div className="space-y-2">
+                          <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                            Top 10 Materials by {getMetricLabel(selectedMetric)}
+                          </h4>
+                          <div className="h-[400px]">
+                            <ResponsiveContainer width="100%" height="100%">
+                              <BarChart data={chartData}>
+                                <CartesianGrid strokeDasharray="3 3" />
+                                <XAxis
+                                  dataKey="name"
+                                  angle={-45}
+                                  textAnchor="end"
+                                  height={100}
+                                  interval={0}
+                                  tick={{ fontSize: 12 }}
+                                />
+                                <YAxis
+                                  tick={{ fontSize: 12 }}
+                                  tickFormatter={formatAxisValue}
+                                />
+                                <Tooltip
+                                  content={({ active, payload }) => {
+                                    if (active && payload && payload.length) {
+                                      const data = payload[0].payload;
+                                      return (
+                                        <div className="rounded-lg border bg-background p-2 shadow-md">
+                                          <p className="font-semibold">{data.name}</p>
+                                          <p className="text-sm">
+                                            {getMetricLabel(selectedMetric)}: {formatValue(data.value)}
+                                          </p>
+                                          <p className="text-sm text-muted-foreground">
+                                            Volume: {data.volume.toFixed(2)} m³
+                                          </p>
+                                        </div>
+                                      );
+                                    }
+                                    return null;
+                                  }}
+                                />
+                                <Bar dataKey="value" radius={[4, 4, 0, 0]}>
+                                  {chartData.map((entry, index) => (
+                                    <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                                  ))}
+                                </Bar>
+                              </BarChart>
+                            </ResponsiveContainer>
+                          </div>
+                        </div>
+
+                        {/* Pie Chart */}
+                        <div className="space-y-2">
+                          <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                            Distribution by {getMetricLabel(selectedMetric)}
+                          </h4>
+                          <div className="h-[400px]">
+                            <ResponsiveContainer width="100%" height="100%">
+                              <PieChart>
+                                <Pie
+                                  data={pieData}
+                                  dataKey="value"
+                                  nameKey="name"
+                                  cx="50%"
+                                  cy="50%"
+                                  outerRadius={120}
+                                  label={({ percent }) => `${(percent * 100).toFixed(1)}%`}
+                                  labelLine={false}
+                                >
+                                  {pieData.map((entry, index) => (
+                                    <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                                  ))}
+                                </Pie>
+                                <Tooltip
+                                  content={({ active, payload }) => {
+                                    if (active && payload && payload.length) {
+                                      const data = payload[0].payload;
+                                      return (
+                                        <div className="rounded-lg border bg-background p-2 shadow-md">
+                                          <p className="font-semibold">{data.name}</p>
+                                          <p className="text-sm">
+                                            {getMetricLabel(selectedMetric)}: {formatValue(data.value)}
+                                          </p>
+                                        </div>
+                                      );
+                                    }
+                                    return null;
+                                  }}
+                                />
+                                <Legend
+                                  verticalAlign="bottom"
+                                  height={36}
+                                  formatter={(value) => value.length > 20 ? value.substring(0, 20) + "..." : value}
+                                />
+                              </PieChart>
+                            </ResponsiveContainer>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="space-y-6">
+                      <Tabs defaultValue="materials" className="w-full">
+                        <TabsList className="grid w-full grid-cols-2">
+                          <TabsTrigger value="materials">Materials</TabsTrigger>
+                          <TabsTrigger value="elements">Elements</TabsTrigger>
+                        </TabsList>
+                        <TabsContent value="materials" className="mt-6">
+                          <DataTable
+                            columns={materialsColumns}
+                            data={materials.map(m => ({
+                              ...m,
+                              material: {
+                                ...m.material,
+                                density: m.material.density ?? 0 // Provide default value of 0 if density is undefined
+                              }
+                            }))}
+                          />
+                        </TabsContent>
+                        <TabsContent value="elements" className="mt-6">
+                          <DataTable columns={elementsColumns} data={elements} />
+                        </TabsContent>
+                      </Tabs>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+
+              {/* CTA */}
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.3 }}
+              >
+                <Card className="bg-gradient-to-r from-orange-600 to-purple-600 text-white overflow-hidden relative">
+                  <motion.div
+                    className="absolute inset-0 bg-white/10"
+                    animate={{
+                      backgroundImage: [
+                        "radial-gradient(circle at 20% 50%, transparent 0%, transparent 50%, white 50%, white 60%, transparent 60%)",
+                        "radial-gradient(circle at 80% 50%, transparent 0%, transparent 50%, white 50%, white 60%, transparent 60%)",
+                        "radial-gradient(circle at 20% 50%, transparent 0%, transparent 50%, white 50%, white 60%, transparent 60%)",
+                      ],
+                    }}
+                    transition={{
+                      duration: 4,
+                      repeat: Infinity,
+                      ease: "easeInOut",
+                    }}
+                  />
+                  <CardContent className="p-12 text-center relative z-10">
+                    <h2 className="text-4xl font-bold mb-4">
+                      Ready to Transform Your Life Cycle Analysis?
+                    </h2>
+                    <p className="text-xl mb-8 opacity-90">
+                      Create a free account to save your results and unlock advanced features.
+                    </p>
+                    <Link href="/sign-up">
+                      <Button
+                        size="lg"
+                        className="bg-white text-orange-600 hover:bg-gray-100 shadow-xl px-8 py-6 text-lg"
+                      >
+                        Create Free Account
+                        <ArrowRight className="ml-2 h-5 w-5" />
+                      </Button>
+                    </Link>
+                  </CardContent>
+                </Card>
+              </motion.div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/file-transfer.ts
+++ b/src/lib/file-transfer.ts
@@ -1,0 +1,21 @@
+// Simple in-memory file transfer service
+class FileTransferService {
+    private pendingFile: File | null = null;
+
+    setPendingFile(file: File) {
+        this.pendingFile = file;
+    }
+
+    getPendingFile(): File | null {
+        const file = this.pendingFile;
+        this.pendingFile = null; // Clear after retrieval
+        return file;
+    }
+
+    hasPendingFile(): boolean {
+        return this.pendingFile !== null;
+    }
+}
+
+// Create singleton instance
+export const fileTransferService = new FileTransferService(); 


### PR DESCRIPTION
## Summary
- support getting material indicators via source
- calculate density generically
- fetch indicators lazily in IFC processing

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and other issues)*
- `npx tsc --noEmit` *(fails with TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684422412c2c8320a68702aa78363e56