### PR TITLE
Add upload deletion management

### DIFF
--- a/src/app/api/projects/[id]/uploads/[uploadId]/route.ts
+++ b/src/app/api/projects/[id]/uploads/[uploadId]/route.ts
@@ -1,19 +1,26 @@
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { connectToDatabase } from "@/lib/mongodb";
-import { Upload, Element } from "@/models";
+import { Upload, Element, Project } from "@/models";
+import { MaterialService } from "@/lib/services/material-service";
 import mongoose from "mongoose";
 
 export const runtime = "nodejs";
 
-export async function DELETE(request: Request, { params }: { params: { id: string; uploadId: string } }) {
+export async function DELETE(
+  request: Request,
+  { params }: { params: { id: string; uploadId: string } },
+) {
   try {
     const { userId } = await auth();
     if (!userId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    if (!mongoose.Types.ObjectId.isValid(params.id) || !mongoose.Types.ObjectId.isValid(params.uploadId)) {
+    if (
+      !mongoose.Types.ObjectId.isValid(params.id) ||
+      !mongoose.Types.ObjectId.isValid(params.uploadId)
+    ) {
       return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
     }
 
@@ -31,10 +38,36 @@ export async function DELETE(request: Request, { params }: { params: { id: strin
 
       if (!upload) {
         await session.abortTransaction();
-        return NextResponse.json({ error: "Upload not found" }, { status: 404 });
+        return NextResponse.json(
+          { error: "Upload not found" },
+          { status: 404 },
+        );
       }
 
-      await Element.deleteMany({ projectId: params.id, uploadId: params.uploadId }).session(session);
+      await Element.deleteMany({
+        projectId: params.id,
+        uploadId: params.uploadId,
+      }).session(session);
+
+      const totals = await MaterialService.updateProjectEmissions(
+        params.id,
+        session,
+      );
+
+      await Project.updateOne(
+        { _id: params.id },
+        {
+          $set: {
+            emissions: {
+              gwp: totals.totalGWP,
+              ubp: totals.totalUBP,
+              penre: totals.totalPENRE,
+              lastCalculated: new Date(),
+            },
+          },
+        },
+      ).session(session);
+
       await Upload.deleteOne({ _id: params.uploadId }).session(session);
 
       await session.commitTransaction();
@@ -47,6 +80,9 @@ export async function DELETE(request: Request, { params }: { params: { id: strin
     }
   } catch (error) {
     console.error("Failed to delete upload:", error);
-    return NextResponse.json({ error: "Failed to delete upload" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Failed to delete upload" },
+      { status: 500 },
+    );
   }
 }

--- a/src/app/api/projects/[id]/uploads/[uploadId]/route.ts
+++ b/src/app/api/projects/[id]/uploads/[uploadId]/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { connectToDatabase } from "@/lib/mongodb";
+import { Upload, Element } from "@/models";
+import mongoose from "mongoose";
+
+export const runtime = "nodejs";
+
+export async function DELETE(request: Request, { params }: { params: { id: string; uploadId: string } }) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(params.id) || !mongoose.Types.ObjectId.isValid(params.uploadId)) {
+      return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+    }
+
+    await connectToDatabase();
+
+    const session = await mongoose.startSession();
+    session.startTransaction();
+
+    try {
+      const upload = await Upload.findOne({
+        _id: params.uploadId,
+        projectId: params.id,
+        userId,
+      }).session(session);
+
+      if (!upload) {
+        await session.abortTransaction();
+        return NextResponse.json({ error: "Upload not found" }, { status: 404 });
+      }
+
+      await Element.deleteMany({ projectId: params.id, uploadId: params.uploadId }).session(session);
+      await Upload.deleteOne({ _id: params.uploadId }).session(session);
+
+      await session.commitTransaction();
+      return NextResponse.json({ success: true });
+    } catch (error) {
+      await session.abortTransaction();
+      throw error;
+    } finally {
+      session.endSession();
+    }
+  } catch (error) {
+    console.error("Failed to delete upload:", error);
+    return NextResponse.json({ error: "Failed to delete upload" }, { status: 500 });
+  }
+}

--- a/src/app/api/projects/[id]/uploads/route.ts
+++ b/src/app/api/projects/[id]/uploads/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { connectToDatabase } from "@/lib/mongodb";
+import { Upload } from "@/models";
+import mongoose from "mongoose";
+
+export const runtime = "nodejs";
+
+export async function GET(request: Request, { params }: { params: { id: string } }) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(params.id)) {
+      return NextResponse.json({ error: "Invalid project ID" }, { status: 400 });
+    }
+
+    await connectToDatabase();
+
+    const uploads = await Upload.find({
+      projectId: params.id,
+      userId,
+    })
+      .sort({ createdAt: -1 })
+      .lean();
+
+    const formatted = uploads.map((u) => ({
+      id: u._id.toString(),
+      filename: u.filename,
+      status: u.status,
+      elementCount: u.elementCount,
+      materialCount: u.materialCount,
+      createdAt: u.createdAt,
+    }));
+
+    return NextResponse.json(formatted);
+  } catch (error) {
+    console.error("Failed to fetch uploads:", error);
+    return NextResponse.json({ error: "Failed to fetch uploads" }, { status: 500 });
+  }
+}

--- a/src/components/upload-history-client.tsx
+++ b/src/components/upload-history-client.tsx
@@ -6,39 +6,8 @@ import { Button } from "@/components/ui/button";
 import { FileDown, Trash2 } from "lucide-react";
 import { UploadModal } from "@/components/upload-modal";
 
-const columns = [
-  {
-    accessorKey: "filename",
-    header: "Filename",
-  },
-  {
-    accessorKey: "status",
-    header: "Status",
-  },
-  {
-    accessorKey: "createdAt",
-    header: "Upload Date",
-    cell: ({ row }: { row: { original: { createdAt: string } } }) =>
-      new Date(row.original.createdAt).toLocaleDateString(),
-  },
-  {
-    accessorKey: "actions",
-    header: "Actions",
-    cell: ({ row }: { row: any }) => (
-      <div className="flex gap-2">
-        <Button variant="ghost" size="sm">
-          <FileDown className="h-4 w-4" />
-        </Button>
-        <Button variant="ghost" size="sm" className="text-destructive">
-          <Trash2 className="h-4 w-4" />
-        </Button>
-      </div>
-    ),
-  },
-];
-
 export function UploadHistoryClient({ projectId }: { projectId: string }) {
-  const [uploadHistory, setUploadHistory] = useState([]);
+  const [uploadHistory, setUploadHistory] = useState<any[]>([]);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   const refreshData = async () => {
@@ -53,12 +22,53 @@ export function UploadHistoryClient({ projectId }: { projectId: string }) {
 
   useEffect(() => {
     refreshData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId]);
 
   const handleUploadComplete = () => {
     setIsRefreshing(true);
     refreshData().finally(() => setIsRefreshing(false));
   };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("Delete this upload?")) return;
+    try {
+      await fetch(`/api/projects/${projectId}/uploads/${id}`, { method: "DELETE" });
+      refreshData();
+    } catch (err) {
+      console.error("Failed to delete upload:", err);
+    }
+  };
+
+  const columns = [
+    { accessorKey: "filename", header: "Filename" },
+    { accessorKey: "status", header: "Status" },
+    {
+      accessorKey: "createdAt",
+      header: "Upload Date",
+      cell: ({ row }: { row: { original: { createdAt: string } } }) =>
+        new Date(row.original.createdAt).toLocaleDateString(),
+    },
+    {
+      accessorKey: "actions",
+      header: "Actions",
+      cell: ({ row }: { row: any }) => (
+        <div className="flex gap-2">
+          <Button variant="ghost" size="sm">
+            <FileDown className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-destructive"
+            onClick={() => handleDelete(row.original.id)}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      ),
+    },
+  ];
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- make upload history interactive
- API to list project uploads
- API to remove an upload and its elements

## Testing
- `npm run lint` *(fails: many existing warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_684512e23ce48320a5acdd841a05c95f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to delete individual uploads and their associated elements within a project.
  - Introduced a new API endpoint to retrieve uploads for a specific project.

- **Improvements**
  - The upload history interface now allows users to delete uploads directly from the list, with a confirmation prompt for safety.

- **Bug Fixes**
  - Improved error handling and user authentication for upload-related actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->