### PR TITLE
Add material mapping management

### DIFF
--- a/src/app/api/materials/mappings/export/route.ts
+++ b/src/app/api/materials/mappings/export/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { connectToDatabase } from "@/lib/mongodb";
+import { Material, Project } from "@/models";
+import { auth } from "@clerk/nextjs/server";
+
+export async function GET() {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    await connectToDatabase();
+    const projects = await Project.find({ userId }).select("_id").lean();
+    const projectIds = projects.map((p) => p._id);
+
+    const mappings = await Material.aggregate([
+      { $match: { projectId: { $in: projectIds }, kbobMatchId: { $exists: true, $ne: null } } },
+      {
+        $group: { _id: "$name", kbobMatchId: { $first: "$kbobMatchId" }, density: { $first: "$density" } },
+      },
+    ]).lean();
+
+    return NextResponse.json(mappings);
+  } catch (error) {
+    console.error("Failed to export mappings:", error);
+    return NextResponse.json({ error: "Failed to export mappings" }, { status: 500 });
+  }
+}

--- a/src/app/api/materials/mappings/import/route.ts
+++ b/src/app/api/materials/mappings/import/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { connectToDatabase } from "@/lib/mongodb";
+import { Material, Project } from "@/models";
+import { auth } from "@clerk/nextjs/server";
+import mongoose from "mongoose";
+
+export async function POST(request: Request) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const mappings = await request.json();
+    if (!Array.isArray(mappings)) {
+      return NextResponse.json({ error: "Invalid mappings" }, { status: 400 });
+    }
+
+    await connectToDatabase();
+    const projects = await Project.find({ userId }).select("_id").lean();
+    const projectIds = projects.map((p) => p._id);
+
+    for (const m of mappings) {
+      if (!m.materialName || !m.kbobMatchId) continue;
+      const kbobId = new mongoose.Types.ObjectId(m.kbobMatchId);
+      await Material.updateMany(
+        { name: m.materialName, projectId: { $in: projectIds } },
+        { kbobMatchId: kbobId, ...(m.density ? { density: m.density } : {}) }
+      );
+    }
+
+    return NextResponse.json({ message: "Mappings imported" });
+  } catch (error) {
+    console.error("Failed to import mappings:", error);
+    return NextResponse.json({ error: "Failed to import mappings" }, { status: 500 });
+  }
+}

--- a/src/app/api/materials/mappings/route.ts
+++ b/src/app/api/materials/mappings/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server";
+import { connectToDatabase } from "@/lib/mongodb";
+import { Material, Project } from "@/models";
+import { auth } from "@clerk/nextjs/server";
+import mongoose from "mongoose";
+
+export async function GET() {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    await connectToDatabase();
+    // Get user's projects
+    const projects = await Project.find({ userId }).select("_id").lean();
+    const projectIds = projects.map((p) => p._id);
+
+    const mappings = await Material.aggregate([
+      {
+        $match: {
+          projectId: { $in: projectIds },
+          kbobMatchId: { $exists: true, $ne: null },
+        },
+      },
+      {
+        $group: {
+          _id: "$name",
+          kbobMatchId: { $first: "$kbobMatchId" },
+          density: { $first: "$density" },
+        },
+      },
+      {
+        $lookup: {
+          from: "indicatorsKBOB",
+          localField: "kbobMatchId",
+          foreignField: "_id",
+          as: "kbob",
+        },
+      },
+      { $unwind: "$kbob" },
+      {
+        $project: {
+          _id: 0,
+          materialName: "$_id",
+          density: 1,
+          kbob: {
+            id: "$kbob._id",
+            Name: "$kbob.Name",
+            GWP: "$kbob.GWP",
+            UBP: "$kbob.UBP",
+            PENRE: "$kbob.PENRE",
+          },
+        },
+      },
+      { $sort: { materialName: 1 } },
+    ]);
+
+    return NextResponse.json(mappings);
+  } catch (error) {
+    console.error("Failed to fetch mappings:", error);
+    return NextResponse.json({ error: "Failed to fetch mappings" }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { materialName, kbobMaterialId, density } = await request.json();
+    if (!materialName || !kbobMaterialId) {
+      return NextResponse.json({ error: "Missing parameters" }, { status: 400 });
+    }
+
+    await connectToDatabase();
+
+    const kbobId = new mongoose.Types.ObjectId(kbobMaterialId);
+
+    const projects = await Project.find({ userId }).select("_id").lean();
+    const projectIds = projects.map((p) => p._id);
+
+    await Material.updateMany(
+      { name: materialName, projectId: { $in: projectIds } },
+      { kbobMatchId: kbobId, ...(density ? { density } : {}) }
+    );
+
+    return NextResponse.json({ message: "Mapping updated" });
+  } catch (error) {
+    console.error("Failed to update mapping:", error);
+    return NextResponse.json({ error: "Failed to update mapping" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { materialName } = await request.json();
+    if (!materialName) {
+      return NextResponse.json({ error: "Missing materialName" }, { status: 400 });
+    }
+
+    await connectToDatabase();
+
+    const projects = await Project.find({ userId }).select("_id").lean();
+    const projectIds = projects.map((p) => p._id);
+
+    await Material.updateMany(
+      { name: materialName, projectId: { $in: projectIds } },
+      { $unset: { kbobMatchId: "", density: "" } }
+    );
+
+    return NextResponse.json({ message: "Mapping removed" });
+  } catch (error) {
+    console.error("Failed to delete mapping:", error);
+    return NextResponse.json({ error: "Failed to delete mapping" }, { status: 500 });
+  }
+}

--- a/src/components/material-mappings-modal.tsx
+++ b/src/components/material-mappings-modal.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+
+interface MappingEntry {
+  materialName: string;
+  density?: number;
+  kbob: { id: string; Name: string };
+}
+
+interface MaterialMappingsModalProps {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+}
+
+export function MaterialMappingsModal({ open, onOpenChange }: MaterialMappingsModalProps) {
+  const [mappings, setMappings] = useState<MappingEntry[]>([]);
+  const [kbobMaterials, setKbobMaterials] = useState<any[]>([]);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    fetch("/api/materials/mappings").then((r) => r.json()).then(setMappings);
+    fetch("/api/kbob").then((r) => r.json()).then(setKbobMaterials);
+  }, [open]);
+
+  const handleUpdate = async (name: string, kbobId: string) => {
+    await fetch("/api/materials/mappings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ materialName: name, kbobMaterialId: kbobId }),
+    });
+    setMappings((m) => m.map((e) => (e.materialName === name ? { ...e, kbob: { ...e.kbob, id: kbobId } } : e)));
+  };
+
+  const handleDelete = async (name: string) => {
+    await fetch("/api/materials/mappings", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ materialName: name }),
+    });
+    setMappings((m) => m.filter((e) => e.materialName !== name));
+  };
+
+  const handleExport = async () => {
+    const res = await fetch("/api/materials/mappings/export");
+    const data = await res.json();
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "material-mappings.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    try {
+      const json = JSON.parse(text);
+      await fetch("/api/materials/mappings/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(json),
+      });
+      setMappings(json as MappingEntry[]);
+    } catch {}
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Saved Material Mappings</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 max-h-[60vh] overflow-y-auto">
+          {mappings.map((m) => (
+            <div key={m.materialName} className="flex items-center justify-between gap-4">
+              <div className="flex-1">
+                <p className="font-medium">{m.materialName}</p>
+              </div>
+              <Select value={m.kbob.id} onValueChange={(v) => handleUpdate(m.materialName, v)}>
+                <SelectTrigger className="w-48">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {kbobMaterials.map((k) => (
+                    <SelectItem key={k._id} value={k._id}>{k.Name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button size="sm" variant="outline" onClick={() => handleDelete(m.materialName)}>
+                Delete
+              </Button>
+            </div>
+          ))}
+        </div>
+        <DialogFooter className="flex justify-between mt-4">
+          <div className="flex items-center gap-2">
+            <Button size="sm" variant="outline" onClick={handleExport}>Export</Button>
+            <Button size="sm" variant="outline" onClick={() => fileRef.current?.click()}>Import</Button>
+            <input ref={fileRef} type="file" accept="application/json" className="hidden" onChange={handleImport} />
+          </div>
+          <Button onClick={() => onOpenChange(false)}>Close</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/materials-library.tsx
+++ b/src/components/materials-library.tsx
@@ -38,6 +38,7 @@ import { MaterialChange } from "@/types/material";
 import Fuse from "fuse.js";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { MaterialMappingsModal } from "@/components/material-mappings-modal";
 import confetti from "canvas-confetti";
 import { CheckIcon } from "@radix-ui/react-icons";
 
@@ -104,6 +105,7 @@ export function MaterialLibraryComponent() {
   const [isKbobOpen, setIsKbobOpen] = useState(false);
   const [previewChanges, setPreviewChanges] = useState<MaterialChange[]>([]);
   const [showPreview, setShowPreview] = useState(false);
+  const [showMappings, setShowMappings] = useState(false);
   const [favoriteMaterials, setFavoriteMaterials] = useState<string[]>([]);
   const [selectedKbobId, setSelectedKbobId] = useState<string | null>(null);
   const [activeSearchId, setActiveSearchId] = useState<string | null>(null);
@@ -914,6 +916,9 @@ export function MaterialLibraryComponent() {
             </Select>
             <div className="flex items-center gap-2">
               <Button onClick={handleShowPreview}>Preview Changes</Button>
+              <Button variant="outline" onClick={() => setShowMappings(true)}>
+                Manage Mappings
+              </Button>
               {Object.keys(temporaryMatches).length > 0 && (
                 <Badge
                   variant="secondary"
@@ -1377,6 +1382,9 @@ export function MaterialLibraryComponent() {
           onNavigateToProject={handleNavigateToProject}
           isLoading={isMatchingInProgress}
         />
+      )}
+      {showMappings && (
+        <MaterialMappingsModal open={showMappings} onOpenChange={setShowMappings} />
       )}
       {/* Add the warning dialog */}
       <AlertDialog open={showLeaveWarning} onOpenChange={setShowLeaveWarning}>


### PR DESCRIPTION
## Summary
- add MaterialMappingsModal component to edit saved mappings
- extend material library with Manage Mappings button
- implement API for listing and updating material mappings
- support mapping import and export

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68451348adc08320807bde28642e58cc