### PR TITLE
Add marketing footer for pre-login pages

### DIFF
--- a/src/app/documentation/page.tsx
+++ b/src/app/documentation/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { motion } from "framer-motion";
 import NavigationHeader from "@/components/navigation-header";
+import MarketingFooter from "@/components/marketing-footer";
 import {
   FileText,
   Upload,
@@ -646,6 +647,7 @@ export default function DocumentationPage() {
           </div>
         </div>
       </section>
+      <MarketingFooter />
     </div>
   );
 }

--- a/src/app/features/page.tsx
+++ b/src/app/features/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { motion } from "framer-motion";
 import NavigationHeader from "@/components/navigation-header";
+import MarketingFooter from "@/components/marketing-footer";
 import {
     Code,
     Upload,
@@ -607,6 +608,7 @@ export default function FeaturesPage() {
                     </p>
                 </motion.div>
             </section>
+            <MarketingFooter />
         </div>
     );
-} 
+}

--- a/src/app/open-source-philosophy/page.tsx
+++ b/src/app/open-source-philosophy/page.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import NavigationHeader from "@/components/navigation-header";
+import MarketingFooter from "@/components/marketing-footer";
 import {
     GitBranch,
     Heart,
@@ -299,6 +300,7 @@ export default function OpenSourcePhilosophyPage() {
                     </motion.div>
                 </motion.div>
             </section>
+            <MarketingFooter />
         </div>
     );
-} 
+}

--- a/src/components/marketing-footer.tsx
+++ b/src/components/marketing-footer.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { Shield } from "lucide-react";
+
+export default function MarketingFooter() {
+  const currentYear = new Date().getFullYear();
+  return (
+    <footer className="bg-gray-100/80 dark:bg-gray-900/50 backdrop-blur-sm py-8 px-4">
+      <div className="max-w-7xl mx-auto space-y-6">
+        <nav className="flex flex-wrap justify-center gap-4 text-sm text-gray-600 dark:text-gray-400">
+          <Link href="/features" className="hover:text-orange-600 dark:hover:text-orange-400">
+            Features
+          </Link>
+          <Link href="/try" className="hover:text-orange-600 dark:hover:text-orange-400">
+            Try Now
+          </Link>
+          <Link href="/documentation" className="hover:text-orange-600 dark:hover:text-orange-400">
+            Documentation
+          </Link>
+          <Link href="/open-source-philosophy" className="hover:text-orange-600 dark:hover:text-orange-400">
+            Philosophy
+          </Link>
+        </nav>
+        <div className="border-t border-gray-200 dark:border-gray-700 pt-6 flex flex-col md:flex-row justify-between items-center gap-4">
+          <div className="flex flex-col md:flex-row items-center gap-4 text-sm text-gray-600 dark:text-gray-400">
+            <p>&copy; {currentYear} IfcLCA. All rights reserved.</p>
+            <span className="hidden md:inline">•</span>
+            <Link
+              href="https://www.lt.plus"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-orange-600 dark:hover:text-orange-400 transition-colors"
+            >
+              Built by LT+
+            </Link>
+          </div>
+          <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+            <Shield className="h-4 w-4" />
+            <span>AGPL-3.0 Licensed</span>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/try-now-page.tsx
+++ b/src/components/try-now-page.tsx
@@ -14,6 +14,7 @@ import Link from "next/link";
 import { useProjectEmissions } from "@/hooks/use-project-emissions";
 import { EmissionsSummaryCard } from "@/components/emissions-summary-card";
 import NavigationHeader from "@/components/navigation-header";
+import MarketingFooter from "@/components/marketing-footer";
 import { fileTransferService } from "@/lib/file-transfer";
 import {
   Upload,
@@ -1071,6 +1072,7 @@ export default function TryNowPage() {
           )}
         </AnimatePresence>
       </div>
+      <MarketingFooter />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create MarketingFooter component based on landing page footer
- display MarketingFooter on features, documentation, philosophy and try-now pages

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68452300be7c8320a414733c79a91651

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a marketing footer to the Documentation, Features, Open Source Philosophy, and Try Now pages, providing navigation links, license information, and branding.
- **Style**
  - Introduced a visually enhanced footer with responsive design and support for light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->