### PR TITLE
Improve SEO metadata for homepage

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,8 +4,9 @@ import { ThemeProvider } from "@/components/theme-provider";
 import "@/styles/globals.css";
 import AuthenticatedLayout from "@/components/authenticated-layout";
 import { nunitoSans } from "@/styles/fonts";
+import type { Metadata } from "next";
 
-export const metadata = {
+export const metadata: Metadata = {
   metadataBase: new URL('https://ifclca.com'),
   title: {
     default: "IfcLCA - Life Cycle Assessment for the Built Environment",
@@ -115,6 +116,12 @@ export default function RootLayout({
     <ClerkProvider appearance={{ baseTheme: undefined }} dynamic>
       <html lang="en" className={nunitoSans.variable} suppressHydrationWarning>
         <head>
+          <title>IfcLCA - Life Cycle Assessment for the Built Environment</title>
+          <meta
+            name="description"
+            content="Open-source Life Cycle Assessment (LCA) tool for architects, engineers, and sustainability experts. Analyze environmental impact of buildings using IFC models and Swiss KBOB data."
+          />
+          <link rel="canonical" href="https://ifclca.com" />
           <script
             type="application/ld+json"
             dangerouslySetInnerHTML={{

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,47 @@
 import { auth } from "@clerk/nextjs/server";
 import { cookies } from "next/headers";
+import type { Metadata } from "next";
 import { Dashboard } from "@/components/dashboard";
 import LandingPage from "@/components/landing-page";
 import { TermsAcceptanceWrapper } from "@/components/terms-acceptance-wrapper";
+
+export const metadata: Metadata = {
+  title: "IfcLCA - Open-source Building LCA",
+  description:
+    "Analyze your building's environmental impact using IFC models and Swiss KBOB metrics with the open-source IfcLCA web application.",
+  alternates: {
+    canonical: "https://ifclca.com/",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  openGraph: {
+    title: "IfcLCA - Open-source Building LCA",
+    description:
+      "Analyze your building's environmental impact using IFC models and Swiss KBOB metrics with the open-source IfcLCA web application.",
+    url: "https://ifclca.com/",
+    siteName: "IfcLCA",
+    locale: "en_US",
+    type: "website",
+    images: [
+      {
+        url: "/LandingPage.jpg",
+        width: 1200,
+        height: 630,
+        alt: "IfcLCA - Life Cycle Assessment for Buildings",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "IfcLCA - Open-source Building LCA",
+    description:
+      "Analyze your building's environmental impact using IFC models and Swiss KBOB metrics with the open-source IfcLCA web application.",
+    images: ["/LandingPage.jpg"],
+    creator: "@ifclca",
+  },
+};
 
 export default async function HomePage() {
   const { userId } = await auth();


### PR DESCRIPTION
## Summary
- add explicit `<title>`, `<meta>` description and canonical link in the layout
- add Metadata typing in the layout file
- keep homepage metadata for rich social previews

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build` *(fails: font fetch errors)*


------
https://chatgpt.com/codex/tasks/task_e_684682c381108320b87260e60976d9c9