### PR TITLE
Support multiple environmental impact data sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2771,7 +2771,6 @@
       "version": "8.17.10",
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.17.10.tgz",
       "integrity": "sha512-S6bqa4DqUooEkInYv/W+Jklv2zjSYCXAhm6qKpAQyOXhTEt5gBXnA7W6aoJ0bjmp9pAeaSj/AZUoz1HCSof/uA==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/debounce": "^1.2.1",
@@ -3036,7 +3035,6 @@
       "version": "20.17.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.6.tgz",
       "integrity": "sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -3065,7 +3063,6 @@
       "version": "18.3.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
       "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3076,7 +3073,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -3098,7 +3094,6 @@
       "version": "0.169.0",
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.169.0.tgz",
       "integrity": "sha512-oan7qCgJBt03wIaK+4xPWclYRPG9wzcg7Z2f5T8xYTNEF95kh0t0lklxLLYBDo7gQiGLYzE6iF4ta7nXF2bcsw==",
-      "peer": true,
       "dependencies": {
         "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
@@ -3304,7 +3299,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3771,7 +3765,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -5038,7 +5031,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5229,7 +5221,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -7102,7 +7093,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
       "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
@@ -7557,7 +7547,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -7844,7 +7833,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7888,7 +7876,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7936,7 +7923,6 @@
       "version": "7.53.1",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.1.tgz",
       "integrity": "sha512-6aiQeBda4zjcuaugWvim9WsGqisoUk+etmFEsSUMm451/Ic8L/UAb7sRtMj3V+Hdzm6mMjU1VhiSzYUZeBm0Vg==",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -8880,7 +8866,6 @@
       "version": "3.4.14",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.14.tgz",
       "integrity": "sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -8958,8 +8943,7 @@
     "node_modules/three": {
       "version": "0.159.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.159.0.tgz",
-      "integrity": "sha512-eCmhlLGbBgucuo4VEA9IO3Qpc7dh8Bd4VKzr7WfW4+8hMcIfoAVi1ev0pJYN9PTTsCslbcKgBwr2wNZ1EvLInA==",
-      "peer": true
+      "integrity": "sha512-eCmhlLGbBgucuo4VEA9IO3Qpc7dh8Bd4VKzr7WfW4+8hMcIfoAVi1ev0pJYN9PTTsCslbcKgBwr2wNZ1EvLInA=="
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.7.8",
@@ -9079,7 +9063,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9278,7 +9261,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/api/lca-materials/route.ts
+++ b/src/app/api/lca-materials/route.ts
@@ -1,0 +1,116 @@
+/**
+ * Unified LCA Materials API
+ * Supports multiple data sources: KBOB, ÖKOBAUDAT, OpenEPD
+ *
+ * GET /api/lca-materials?source=kbob|okobaudat|openepd&q=search&limit=50
+ * GET /api/lca-materials/sources - Get available sources info
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import {
+  getLcaService,
+  getAvailableSources,
+  searchAllSources,
+  getDefaultSource,
+} from "@/lib/services/lca";
+import type { LcaDataSource } from "@/lib/types/lca";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+
+    // Parse source parameter
+    const sourceParam = searchParams.get("source");
+    const validSources: LcaDataSource[] = ["kbob", "okobaudat", "openepd"];
+    const source: LcaDataSource | "all" =
+      sourceParam === "all"
+        ? "all"
+        : validSources.includes(sourceParam as LcaDataSource)
+          ? (sourceParam as LcaDataSource)
+          : getDefaultSource();
+
+    // Parse other parameters
+    const query = searchParams.get("q") || "";
+    const limit = Math.min(
+      parseInt(searchParams.get("limit") || "50", 10),
+      200
+    );
+    const forceRefresh = searchParams.get("refresh") === "true";
+
+    // Handle search across all sources
+    if (source === "all") {
+      if (query.length < 2) {
+        return NextResponse.json({
+          materials: [],
+          source: "all",
+          sources: getAvailableSources(),
+          query,
+          count: 0,
+        });
+      }
+
+      const materials = await searchAllSources(query, limit);
+      return NextResponse.json({
+        materials,
+        source: "all",
+        sources: getAvailableSources(),
+        query,
+        count: materials.length,
+      });
+    }
+
+    // Get service for specific source
+    const service = getLcaService(source);
+
+    // Handle search query
+    if (query && query.length >= 2) {
+      const materials = await service.search(query, limit);
+      return NextResponse.json({
+        materials,
+        source,
+        sourceInfo: {
+          name: service.displayName,
+          flag: service.countryFlag,
+          indicators: service.getAvailableIndicators(),
+        },
+        query,
+        count: materials.length,
+      });
+    }
+
+    // Return all materials from cache
+    // For KBOB, this triggers sync if needed
+    const materials = await service.getAll();
+
+    // If force refresh requested, trigger sync
+    if (forceRefresh) {
+      // Don't await - let it run in background
+      service.sync().catch((error) => {
+        logger.error(`[LCA API] Sync error for ${source}:`, error);
+      });
+    }
+
+    return NextResponse.json({
+      materials,
+      source,
+      sourceInfo: {
+        name: service.displayName,
+        flag: service.countryFlag,
+        indicators: service.getAvailableIndicators(),
+      },
+      count: materials.length,
+    });
+  } catch (error) {
+    logger.error("[LCA API] Error fetching LCA materials:", error);
+    return NextResponse.json(
+      {
+        error: "Failed to fetch LCA materials",
+        message: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/lca-materials/sources/route.ts
+++ b/src/app/api/lca-materials/sources/route.ts
@@ -1,0 +1,21 @@
+/**
+ * LCA Data Sources API
+ * Returns information about available LCA data sources
+ *
+ * GET /api/lca-materials/sources
+ */
+
+import { NextResponse } from "next/server";
+import { getAvailableSources, getDefaultSource } from "@/lib/services/lca";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const sources = getAvailableSources();
+  const defaultSource = getDefaultSource();
+
+  return NextResponse.json({
+    sources,
+    defaultSource,
+  });
+}

--- a/src/components/lca-source-selector.tsx
+++ b/src/components/lca-source-selector.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import type { LcaDataSource, LcaDataSourceInfo } from "@/lib/types/lca";
+
+interface LcaSourceSelectorProps {
+  value: LcaDataSource;
+  onChange: (source: LcaDataSource) => void;
+  className?: string;
+  showIndicators?: boolean;
+  disabled?: boolean;
+}
+
+export function LcaSourceSelector({
+  value,
+  onChange,
+  className,
+  showIndicators = true,
+  disabled = false,
+}: LcaSourceSelectorProps) {
+  const [sources, setSources] = useState<LcaDataSourceInfo[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchSources() {
+      try {
+        const response = await fetch("/api/lca-materials/sources");
+        if (response.ok) {
+          const data = await response.json();
+          setSources(data.sources);
+        }
+      } catch (error) {
+        console.error("Failed to fetch LCA sources:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchSources();
+  }, []);
+
+  const selectedSource = sources.find((s) => s.id === value);
+
+  const getIndicatorBadges = useCallback((indicators: string[]) => {
+    return indicators.map((indicator) => {
+      const label = indicator.toUpperCase();
+      const colors: Record<string, string> = {
+        gwp: "bg-emerald-100 text-emerald-700 border-emerald-200",
+        ubp: "bg-blue-100 text-blue-700 border-blue-200",
+        penre: "bg-orange-100 text-orange-700 border-orange-200",
+      };
+      return (
+        <Badge
+          key={indicator}
+          variant="outline"
+          className={`text-[10px] px-1 py-0 ${colors[indicator] || ""}`}
+        >
+          {label}
+        </Badge>
+      );
+    });
+  }, []);
+
+  if (isLoading) {
+    return (
+      <Select disabled>
+        <SelectTrigger className={className}>
+          <SelectValue placeholder="Loading sources..." />
+        </SelectTrigger>
+      </Select>
+    );
+  }
+
+  return (
+    <TooltipProvider>
+      <Select value={value} onValueChange={onChange} disabled={disabled}>
+        <SelectTrigger className={className}>
+          <SelectValue>
+            {selectedSource && (
+              <div className="flex items-center gap-2">
+                <span>{selectedSource.countryFlag}</span>
+                <span>{selectedSource.name}</span>
+                {!selectedSource.isConfigured && (
+                  <Badge variant="secondary" className="text-[10px] px-1 py-0">
+                    Not configured
+                  </Badge>
+                )}
+              </div>
+            )}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          {sources.map((source) => (
+            <Tooltip key={source.id}>
+              <TooltipTrigger asChild>
+                <SelectItem
+                  value={source.id}
+                  disabled={!source.isConfigured}
+                  className="cursor-pointer"
+                >
+                  <div className="flex items-center justify-between w-full gap-4">
+                    <div className="flex items-center gap-2">
+                      <span className="text-lg">{source.countryFlag}</span>
+                      <div className="flex flex-col">
+                        <span className="font-medium">{source.name}</span>
+                        <span className="text-xs text-muted-foreground">
+                          {source.country}
+                        </span>
+                      </div>
+                    </div>
+                    {showIndicators && (
+                      <div className="flex items-center gap-1">
+                        {getIndicatorBadges(source.indicators)}
+                      </div>
+                    )}
+                    {!source.isConfigured && (
+                      <Badge
+                        variant="secondary"
+                        className="text-[10px] px-1 py-0 ml-2"
+                      >
+                        API key required
+                      </Badge>
+                    )}
+                  </div>
+                </SelectItem>
+              </TooltipTrigger>
+              <TooltipContent side="left" className="max-w-xs">
+                <p className="text-sm">{source.description}</p>
+                {source.docsUrl && (
+                  <a
+                    href={source.docsUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-blue-500 hover:underline mt-1 block"
+                  >
+                    Documentation
+                  </a>
+                )}
+              </TooltipContent>
+            </Tooltip>
+          ))}
+        </SelectContent>
+      </Select>
+    </TooltipProvider>
+  );
+}
+
+export function LcaSourceBadge({
+  source,
+  className,
+}: {
+  source: LcaDataSource;
+  className?: string;
+}) {
+  const sourceInfo: Record<LcaDataSource, { flag: string; name: string }> = {
+    kbob: { flag: "🇨🇭", name: "KBOB" },
+    okobaudat: { flag: "🇩🇪", name: "ÖKOBAUDAT" },
+    openepd: { flag: "🌍", name: "OpenEPD" },
+  };
+
+  const info = sourceInfo[source];
+
+  return (
+    <Badge variant="outline" className={className}>
+      <span className="mr-1">{info.flag}</span>
+      {info.name}
+    </Badge>
+  );
+}

--- a/src/lib/services/lca/index.ts
+++ b/src/lib/services/lca/index.ts
@@ -1,0 +1,13 @@
+/**
+ * LCA Services - Multi-source Life Cycle Assessment data providers
+ *
+ * Supported sources:
+ * - KBOB (Switzerland): GWP, UBP, PENRE
+ * - ÖKOBAUDAT (Germany): GWP, PENRE
+ * - OpenEPD/EC3 (Global): GWP
+ */
+
+export * from "./kbob-lca-service";
+export * from "./okobaudat-lca-service";
+export * from "./openepd-lca-service";
+export * from "./lca-service-factory";

--- a/src/lib/services/lca/kbob-lca-service.ts
+++ b/src/lib/services/lca/kbob-lca-service.ts
@@ -1,0 +1,419 @@
+/**
+ * KBOB LCA Service
+ * Implements ILcaDataService for Swiss KBOB materials database
+ * Wraps existing KbobService with unified interface
+ */
+
+import { logger } from "@/lib/logger";
+import { connectToDatabase } from "@/lib/mongodb";
+import { KBOBMaterial } from "@/models/kbob";
+import { KBOB_API_CONFIG } from "@/lib/config/kbob";
+import type { KbobApiResponse, KbobApiMaterial } from "@/types/kbob-api";
+import type {
+  ILcaDataService,
+  LcaDataSource,
+  LcaIndicator,
+  LcaMaterialData,
+  LcaMaterialSearchResult,
+} from "@/lib/types/lca";
+import { createLcaMaterialId } from "@/lib/types/lca";
+
+export class KbobLcaService implements ILcaDataService {
+  readonly source: LcaDataSource = "kbob";
+  readonly displayName = "KBOB (Switzerland)";
+  readonly countryFlag = "🇨🇭";
+
+  // Lock to prevent concurrent syncs
+  private static _syncInProgress: Promise<void> | null = null;
+
+  getAvailableIndicators(): LcaIndicator[] {
+    return ["gwp", "ubp", "penre"];
+  }
+
+  /**
+   * Check if cache needs refresh
+   */
+  async needsRefresh(): Promise<boolean> {
+    await connectToDatabase();
+
+    const latestMaterial = await KBOBMaterial.findOne({
+      lastUpdated: { $exists: true },
+    })
+      .sort({ lastUpdated: -1 })
+      .lean();
+
+    if (!latestMaterial || !latestMaterial.lastUpdated) {
+      logger.info("[KBOB LCA] No cached materials found, refresh needed");
+      return true;
+    }
+
+    const age =
+      Date.now() - new Date(latestMaterial.lastUpdated).getTime();
+    const needsRefresh = age > KBOB_API_CONFIG.syncInterval;
+
+    if (needsRefresh) {
+      logger.info(
+        `[KBOB LCA] Cache is ${Math.floor(age / (60 * 60 * 1000))} hours old, refresh needed`
+      );
+    }
+
+    return needsRefresh;
+  }
+
+  /**
+   * Fetch all materials from the lcadata.ch API
+   */
+  private async fetchFromApi(): Promise<KbobApiResponse> {
+    if (
+      !KBOB_API_CONFIG.apiKey ||
+      typeof KBOB_API_CONFIG.apiKey !== "string" ||
+      KBOB_API_CONFIG.apiKey.trim() === ""
+    ) {
+      const error =
+        "KBOB API key is not configured. Set KBOB_API_KEY environment variable.";
+      logger.error(`[KBOB LCA] ${error}`);
+      throw new Error(error);
+    }
+
+    const url = `${KBOB_API_CONFIG.baseUrl}/api/kbob/materials?pageSize=all`;
+
+    try {
+      logger.info(`[KBOB LCA] Fetching materials from API: ${url}`);
+
+      const response = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${KBOB_API_CONFIG.apiKey}`,
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        signal: AbortSignal.timeout(60000),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        logger.error(
+          `[KBOB LCA] API error: ${response.status} ${response.statusText} - ${errorText}`
+        );
+        throw new Error(
+          `KBOB API error: ${response.status} ${response.statusText}`
+        );
+      }
+
+      const data: KbobApiResponse = await response.json();
+      logger.info(
+        `[KBOB LCA] Fetched ${data.materials.length} materials from API (version ${data.version})`
+      );
+
+      return data;
+    } catch (error) {
+      logger.error("[KBOB LCA] Failed to fetch from API:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Transform API material to MongoDB document format
+   */
+  private transformApiMaterial(
+    apiMaterial: KbobApiMaterial,
+    version: string
+  ): any {
+    let density: number | null = null;
+    if (typeof apiMaterial.density === "number") {
+      density = apiMaterial.density;
+    } else if (
+      typeof apiMaterial.density === "string" &&
+      apiMaterial.density !== "" &&
+      apiMaterial.density !== "-"
+    ) {
+      const parsed = parseFloat(apiMaterial.density);
+      if (!isNaN(parsed)) {
+        density = parsed;
+      }
+    }
+
+    return {
+      uuid: apiMaterial.uuid,
+      nameDE: apiMaterial.nameDE,
+      nameFR: apiMaterial.nameFR,
+      Name: apiMaterial.nameDE,
+      group: apiMaterial.group,
+      Category: apiMaterial.group,
+      version: version,
+      lastUpdated: new Date(),
+      gwpTotal: apiMaterial.gwpTotal,
+      ubp21Total: apiMaterial.ubp21Total,
+      primaryEnergyNonRenewableTotal: apiMaterial.primaryEnergyNonRenewableTotal,
+      density: density,
+      unit: apiMaterial.unit,
+    };
+  }
+
+  /**
+   * Transform MongoDB document to unified LcaMaterialData format
+   */
+  private toUnifiedFormat(kbob: any): LcaMaterialData {
+    const density =
+      typeof kbob.density === "number"
+        ? kbob.density
+        : parseFloat(kbob.density) || 0;
+
+    return {
+      id: createLcaMaterialId("kbob", kbob.uuid),
+      sourceId: kbob.uuid,
+      source: "kbob",
+      name: kbob.Name || kbob.nameDE || "Unknown",
+      nameDE: kbob.nameDE,
+      nameFR: kbob.nameFR,
+      category: kbob.group || kbob.Category,
+      density: density,
+      declaredUnit: kbob.unit || "kg",
+      gwp: kbob.gwpTotal ?? 0,
+      ubp: kbob.ubp21Total ?? null,
+      penre: kbob.primaryEnergyNonRenewableTotal ?? null,
+      version: kbob.version,
+      lastUpdated: kbob.lastUpdated,
+    };
+  }
+
+  /**
+   * Transform MongoDB document to search result format
+   */
+  private toSearchResult(kbob: any): LcaMaterialSearchResult {
+    const density =
+      typeof kbob.density === "number"
+        ? kbob.density
+        : parseFloat(kbob.density) || null;
+
+    return {
+      id: createLcaMaterialId("kbob", kbob.uuid),
+      sourceId: kbob.uuid,
+      source: "kbob",
+      name: kbob.Name || kbob.nameDE || "Unknown",
+      nameDE: kbob.nameDE,
+      category: kbob.group || kbob.Category,
+      density: density,
+      gwp: kbob.gwpTotal ?? null,
+      ubp: kbob.ubp21Total ?? null,
+      penre: kbob.primaryEnergyNonRenewableTotal ?? null,
+    };
+  }
+
+  /**
+   * Sync materials from API to MongoDB
+   */
+  async sync(): Promise<{ synced: number; errors: number }> {
+    await connectToDatabase();
+
+    try {
+      const apiResponse = await this.fetchFromApi();
+      const { materials, version } = apiResponse;
+
+      let synced = 0;
+      let errors = 0;
+
+      logger.info(
+        `[KBOB LCA] Starting sync of ${materials.length} materials...`
+      );
+
+      const batchSize = 100;
+      for (let i = 0; i < materials.length; i += batchSize) {
+        const batch = materials.slice(i, i + batchSize);
+
+        const bulkOps = batch.map((apiMaterial) => {
+          const transformed = this.transformApiMaterial(apiMaterial, version);
+
+          return {
+            updateOne: {
+              filter: { uuid: apiMaterial.uuid },
+              update: {
+                $set: transformed,
+                $setOnInsert: {
+                  createdAt: new Date(),
+                },
+              },
+              upsert: true,
+            },
+          };
+        });
+
+        try {
+          const result = await KBOBMaterial.bulkWrite(bulkOps, {
+            ordered: false,
+          });
+          synced += result.modifiedCount + result.upsertedCount;
+          logger.info(
+            `[KBOB LCA] Processed batch ${Math.floor(i / batchSize) + 1}: ${result.modifiedCount} updated, ${result.upsertedCount} inserted`
+          );
+        } catch (error) {
+          logger.error(
+            `[KBOB LCA] Error processing batch ${Math.floor(i / batchSize) + 1}:`,
+            error
+          );
+          errors += batch.length;
+        }
+      }
+
+      logger.info(
+        `[KBOB LCA] Sync completed: ${synced} materials synced, ${errors} errors`
+      );
+      return { synced, errors };
+    } catch (error) {
+      logger.error("[KBOB LCA] Sync failed:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Search materials by query
+   */
+  async search(query: string, limit: number = 50): Promise<LcaMaterialSearchResult[]> {
+    if (!query || query.length < 2) {
+      return [];
+    }
+
+    await connectToDatabase();
+
+    try {
+      // Escape special regex characters
+      const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+      const materials = await KBOBMaterial.find({
+        $and: [
+          // Must have valid indicators
+          { gwpTotal: { $exists: true, $ne: null } },
+          { ubp21Total: { $exists: true, $ne: null } },
+          { primaryEnergyNonRenewableTotal: { $exists: true, $ne: null } },
+          { density: { $exists: true, $ne: null, $nin: ["-", "", 0] } },
+          // Search in name fields
+          {
+            $or: [
+              { Name: { $regex: escapedQuery, $options: "i" } },
+              { nameDE: { $regex: escapedQuery, $options: "i" } },
+              { nameFR: { $regex: escapedQuery, $options: "i" } },
+              { group: { $regex: escapedQuery, $options: "i" } },
+            ],
+          },
+        ],
+      })
+        .limit(limit)
+        .sort({ Name: 1 })
+        .lean();
+
+      return materials.map((m) => this.toSearchResult(m));
+    } catch (error) {
+      logger.error("[KBOB LCA] Search error:", error);
+      return [];
+    }
+  }
+
+  /**
+   * Get a single material by ID
+   */
+  async getById(id: string): Promise<LcaMaterialData | null> {
+    // Extract UUID from prefixed ID
+    const prefix = "KBOB_";
+    if (!id.startsWith(prefix)) {
+      return null;
+    }
+    const uuid = id.slice(prefix.length);
+
+    await connectToDatabase();
+
+    const material = await KBOBMaterial.findOne({ uuid }).lean();
+    if (!material) {
+      return null;
+    }
+
+    return this.toUnifiedFormat(material);
+  }
+
+  /**
+   * Get all valid materials from cache
+   */
+  async getAll(): Promise<LcaMaterialData[]> {
+    try {
+      await connectToDatabase();
+    } catch (error) {
+      logger.error("[KBOB LCA] Database connection failed:", error);
+      return [];
+    }
+
+    try {
+      const shouldRefresh = await this.needsRefresh();
+
+      if (shouldRefresh) {
+        if (KbobLcaService._syncInProgress) {
+          logger.info(
+            "[KBOB LCA] Sync already in progress, waiting for completion..."
+          );
+          try {
+            await KbobLcaService._syncInProgress;
+          } catch {
+            // Error already logged
+          }
+        } else {
+          KbobLcaService._syncInProgress = this.sync()
+            .then(() => {
+              KbobLcaService._syncInProgress = null;
+            })
+            .catch((error) => {
+              logger.error("[KBOB LCA] Background sync failed:", error);
+              KbobLcaService._syncInProgress = null;
+            });
+        }
+      }
+
+      const materials = await (
+        KBOBMaterial.findValidMaterials() as any
+      ).lean();
+
+      if (materials.length === 0 && shouldRefresh) {
+        logger.info(
+          "[KBOB LCA] No cached materials, waiting for initial sync..."
+        );
+        try {
+          if (!KbobLcaService._syncInProgress) {
+            KbobLcaService._syncInProgress = this.sync()
+              .then(() => {
+                KbobLcaService._syncInProgress = null;
+              })
+              .catch((error) => {
+                logger.error("[KBOB LCA] Initial sync failed:", error);
+                KbobLcaService._syncInProgress = null;
+                throw error;
+              });
+          }
+
+          await Promise.race([
+            KbobLcaService._syncInProgress,
+            new Promise((resolve) => setTimeout(resolve, 5000)),
+          ]);
+
+          const refreshedMaterials = await (
+            KBOBMaterial.findValidMaterials() as any
+          ).lean();
+          return refreshedMaterials.map((m: any) => this.toUnifiedFormat(m));
+        } catch (error) {
+          logger.error("[KBOB LCA] Initial sync failed:", error);
+          return [];
+        }
+      }
+
+      return materials.map((m: any) => this.toUnifiedFormat(m));
+    } catch (error) {
+      logger.error("[KBOB LCA] Error getting materials:", error);
+      return [];
+    }
+  }
+}
+
+// Singleton instance
+let _instance: KbobLcaService | null = null;
+
+export function getKbobLcaService(): KbobLcaService {
+  if (!_instance) {
+    _instance = new KbobLcaService();
+  }
+  return _instance;
+}

--- a/src/lib/services/lca/lca-service-factory.ts
+++ b/src/lib/services/lca/lca-service-factory.ts
@@ -1,0 +1,173 @@
+/**
+ * LCA Service Factory
+ * Provides unified access to multiple LCA data sources
+ */
+
+import { logger } from "@/lib/logger";
+import type {
+  ILcaDataService,
+  LcaDataSource,
+  LcaDataSourceInfo,
+  LcaMaterialData,
+  LcaMaterialSearchResult,
+} from "@/lib/types/lca";
+import { LCA_SOURCE_CONFIG, parseLcaMaterialId } from "@/lib/types/lca";
+import { KbobLcaService, getKbobLcaService } from "./kbob-lca-service";
+import { OkobaudatLcaService, getOkobaudatLcaService } from "./okobaudat-lca-service";
+import { OpenEpdLcaService, getOpenEpdLcaService } from "./openepd-lca-service";
+
+/**
+ * Get the LCA service for a specific data source
+ */
+export function getLcaService(source: LcaDataSource): ILcaDataService {
+  switch (source) {
+    case "kbob":
+      return getKbobLcaService();
+    case "okobaudat":
+      return getOkobaudatLcaService();
+    case "openepd":
+      return getOpenEpdLcaService();
+    default:
+      throw new Error(`Unknown LCA data source: ${source}`);
+  }
+}
+
+/**
+ * Get all available LCA services
+ */
+export function getAllLcaServices(): ILcaDataService[] {
+  return [
+    getKbobLcaService(),
+    getOkobaudatLcaService(),
+    getOpenEpdLcaService(),
+  ];
+}
+
+/**
+ * Get information about all available data sources
+ */
+export function getAvailableSources(): LcaDataSourceInfo[] {
+  const sources: LcaDataSourceInfo[] = [];
+
+  // KBOB - check if API key is configured
+  const kbobConfigured = Boolean(process.env.KBOB_API_KEY);
+  sources.push({
+    ...LCA_SOURCE_CONFIG.kbob,
+    isConfigured: kbobConfigured,
+  });
+
+  // ÖKOBAUDAT - no API key required
+  sources.push({
+    ...LCA_SOURCE_CONFIG.okobaudat,
+    isConfigured: true, // Always available (free API)
+  });
+
+  // OpenEPD - check if API key is configured
+  const openEpdConfigured = Boolean(process.env.OPENEPD_API_KEY);
+  sources.push({
+    ...LCA_SOURCE_CONFIG.openepd,
+    isConfigured: openEpdConfigured,
+  });
+
+  return sources;
+}
+
+/**
+ * Get a material by its source-prefixed ID (auto-detects source)
+ */
+export async function getMaterialById(
+  materialId: string
+): Promise<LcaMaterialData | null> {
+  const parsed = parseLcaMaterialId(materialId);
+  if (!parsed) {
+    logger.warn(`[LCA Factory] Invalid material ID format: ${materialId}`);
+    return null;
+  }
+
+  const service = getLcaService(parsed.source);
+  return service.getById(materialId);
+}
+
+/**
+ * Search across all configured data sources
+ */
+export async function searchAllSources(
+  query: string,
+  limit: number = 20
+): Promise<LcaMaterialSearchResult[]> {
+  const sources = getAvailableSources().filter((s) => s.isConfigured);
+  const perSourceLimit = Math.ceil(limit / sources.length);
+
+  const searchPromises = sources.map(async (sourceInfo) => {
+    try {
+      const service = getLcaService(sourceInfo.id);
+      return await service.search(query, perSourceLimit);
+    } catch (error) {
+      logger.error(
+        `[LCA Factory] Search error for ${sourceInfo.id}:`,
+        error
+      );
+      return [];
+    }
+  });
+
+  const results = await Promise.all(searchPromises);
+  const combined = results.flat();
+
+  // Sort by source priority (KBOB first, then ÖKOBAUDAT, then OpenEPD)
+  const sourcePriority: Record<LcaDataSource, number> = {
+    kbob: 0,
+    okobaudat: 1,
+    openepd: 2,
+  };
+
+  combined.sort((a, b) => {
+    const priorityDiff = sourcePriority[a.source] - sourcePriority[b.source];
+    if (priorityDiff !== 0) return priorityDiff;
+    return a.name.localeCompare(b.name);
+  });
+
+  return combined.slice(0, limit);
+}
+
+/**
+ * Sync all configured data sources
+ */
+export async function syncAllSources(): Promise<
+  Record<LcaDataSource, { synced: number; errors: number }>
+> {
+  const results: Record<LcaDataSource, { synced: number; errors: number }> = {
+    kbob: { synced: 0, errors: 0 },
+    okobaudat: { synced: 0, errors: 0 },
+    openepd: { synced: 0, errors: 0 },
+  };
+
+  const sources = getAvailableSources().filter((s) => s.isConfigured);
+
+  for (const sourceInfo of sources) {
+    try {
+      const service = getLcaService(sourceInfo.id);
+      results[sourceInfo.id] = await service.sync();
+      logger.info(
+        `[LCA Factory] ${sourceInfo.name} sync: ${results[sourceInfo.id].synced} materials`
+      );
+    } catch (error) {
+      logger.error(`[LCA Factory] Sync error for ${sourceInfo.id}:`, error);
+      results[sourceInfo.id] = { synced: 0, errors: 1 };
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Get default LCA source based on configuration
+ * Returns the first configured source (priority: KBOB > ÖKOBAUDAT > OpenEPD)
+ */
+export function getDefaultSource(): LcaDataSource {
+  if (process.env.KBOB_API_KEY) {
+    return "kbob";
+  }
+  // ÖKOBAUDAT is always available
+  return "okobaudat";
+}

--- a/src/lib/services/lca/okobaudat-lca-service.ts
+++ b/src/lib/services/lca/okobaudat-lca-service.ts
@@ -1,0 +1,745 @@
+/**
+ * ÖKOBAUDAT LCA Service
+ * Implements ILcaDataService for German ÖKOBAUDAT EPD database
+ * Free API access, no authentication required
+ */
+
+import { logger } from "@/lib/logger";
+import { connectToDatabase } from "@/lib/mongodb";
+import { OkobaudatMaterial, type IOkobaudatMaterial } from "@/models/okobaudat";
+import type {
+  ILcaDataService,
+  LcaDataSource,
+  LcaIndicator,
+  LcaMaterialData,
+  LcaMaterialSearchResult,
+} from "@/lib/types/lca";
+import { createLcaMaterialId } from "@/lib/types/lca";
+
+// Configuration
+const OKOBAUDAT_CONFIG = {
+  baseUrl:
+    process.env.OKOBAUDAT_BASE_URL ||
+    "https://oekobaudat.de/OEKOBAU.DAT/resource",
+  datastockId:
+    process.env.OKOBAUDAT_DATASTOCK_ID ||
+    "cd2bda71-760b-4fcc-8a0b-3877c10000a8",
+  complianceA2:
+    process.env.OKOBAUDAT_COMPLIANCE_A2 ||
+    "c0016b33-8cf7-415c-ac6e-deba0d21440d",
+  syncInterval: 7 * 24 * 60 * 60 * 1000, // 7 days
+  requestTimeout: 30000, // 30 seconds
+};
+
+interface OkobaudatProcessInfo {
+  uuid: string;
+  name?: string | { value: string; lang: string }[];
+}
+
+interface OkobaudatSearchResponse {
+  data?: OkobaudatProcessInfo[];
+  totalCount?: number;
+}
+
+export class OkobaudatLcaService implements ILcaDataService {
+  readonly source: LcaDataSource = "okobaudat";
+  readonly displayName = "ÖKOBAUDAT (Germany)";
+  readonly countryFlag = "🇩🇪";
+
+  private cache: Map<string, LcaMaterialData> = new Map();
+
+  getAvailableIndicators(): LcaIndicator[] {
+    // ÖKOBAUDAT has GWP and PENRE but not UBP (Swiss-specific)
+    return ["gwp", "penre"];
+  }
+
+  /**
+   * Check if cache needs refresh
+   */
+  async needsRefresh(): Promise<boolean> {
+    await connectToDatabase();
+
+    const latestMaterial = await OkobaudatMaterial.findOne({
+      lastUpdated: { $exists: true },
+    })
+      .sort({ lastUpdated: -1 })
+      .lean();
+
+    if (!latestMaterial || !latestMaterial.lastUpdated) {
+      logger.info("[ÖKOBAUDAT LCA] No cached materials found");
+      return true;
+    }
+
+    const age = Date.now() - new Date(latestMaterial.lastUpdated).getTime();
+    const needsRefresh = age > OKOBAUDAT_CONFIG.syncInterval;
+
+    if (needsRefresh) {
+      logger.info(
+        `[ÖKOBAUDAT LCA] Cache is ${Math.floor(age / (24 * 60 * 60 * 1000))} days old`
+      );
+    }
+
+    return needsRefresh;
+  }
+
+  /**
+   * Extract name from ÖKOBAUDAT EPD data structure
+   */
+  private extractEpdName(epdData: any): string {
+    try {
+      const processInfo = epdData?.processInformation || {};
+      const datasetInfo = processInfo?.dataSetInformation || {};
+      const nameObj = datasetInfo?.name || {};
+      const baseNames = nameObj?.baseName || [];
+
+      if (!baseNames || baseNames.length === 0) {
+        return epdData?.uuid || "Unknown";
+      }
+
+      // Prefer German name
+      for (const entry of baseNames) {
+        if (entry?.lang === "de" && entry?.value) {
+          return entry.value;
+        }
+      }
+
+      // Fallback to English
+      for (const entry of baseNames) {
+        if (entry?.lang === "en" && entry?.value) {
+          return entry.value;
+        }
+      }
+
+      // Fallback to first entry
+      if (baseNames[0]?.value) {
+        return baseNames[0].value;
+      }
+    } catch {
+      // Ignore parsing errors
+    }
+
+    return epdData?.uuid || "Unknown";
+  }
+
+  /**
+   * Extract reference exchange from EPD data
+   */
+  private extractReferenceExchange(epdData: any): any | null {
+    const exchanges = epdData?.exchanges;
+    if (!exchanges || typeof exchanges !== "object") {
+      return null;
+    }
+
+    const exchangeList = exchanges?.exchange;
+    if (!Array.isArray(exchangeList)) {
+      return null;
+    }
+
+    for (const exchange of exchangeList) {
+      if (exchange?.referenceFlow) {
+        return exchange;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Extract declared unit from reference exchange
+   */
+  private extractDeclaredUnit(referenceExchange: any): string {
+    const flowProps = referenceExchange?.flowProperties;
+    if (!flowProps || !Array.isArray(flowProps)) {
+      return "unknown";
+    }
+
+    // Find reference flow property
+    const refProp =
+      flowProps.find((p: any) => p?.referenceFlowProperty) || flowProps[0];
+
+    const unit = refProp?.referenceUnit || "unknown";
+    // Normalize common variations
+    return unit.toLowerCase().replace("³", "3").replace("²", "2");
+  }
+
+  /**
+   * Extract density from material properties
+   */
+  private extractDensity(referenceExchange: any): number | null {
+    const materialProps = referenceExchange?.materialProperties;
+    if (!materialProps || !Array.isArray(materialProps)) {
+      return null;
+    }
+
+    for (const prop of materialProps) {
+      const propName = (prop?.name || "").toLowerCase();
+      const propValue = prop?.value;
+
+      if (
+        (propName.includes("density") || propName.includes("rohdichte")) &&
+        propValue
+      ) {
+        const parsed = parseFloat(propValue);
+        if (!isNaN(parsed) && parsed > 0) {
+          return parsed;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Extract GWP-total from LCIAResults
+   * Sums A1-A3 + C3 (or C4) to match KBOB "Total" methodology per EN 15978/15804
+   */
+  private extractGwpTotal(epdData: any): number | null {
+    const lciaResults = epdData?.LCIAResults;
+    if (!lciaResults || typeof lciaResults !== "object") {
+      return null;
+    }
+
+    const lciaResultList = lciaResults?.LCIAResult;
+    if (!Array.isArray(lciaResultList)) {
+      return null;
+    }
+
+    // Look for GWP indicator (prefer GWP-total)
+    let bestResult: any = null;
+
+    for (const result of lciaResultList) {
+      const methodRef = result?.referenceToLCIAMethodDataSet || {};
+      const shortDesc = methodRef?.shortDescription || [];
+
+      for (const desc of shortDesc) {
+        if (typeof desc !== "object") continue;
+        const value = (desc?.value || "").toLowerCase();
+        const lang = desc?.lang || "";
+
+        if (
+          (lang === "en" || lang === "de") &&
+          value.includes("global warming potential")
+        ) {
+          // Prefer "total" if available
+          if (value.includes("total")) {
+            bestResult = result;
+            break;
+          } else if (!bestResult) {
+            bestResult = result;
+          }
+        }
+      }
+      if (bestResult && (bestResult as any)?.isTotal) break;
+    }
+
+    if (!bestResult) {
+      return null;
+    }
+
+    // First try direct amount field
+    const amount = bestResult?.amount;
+    if (amount !== undefined && amount !== null) {
+      const parsed = parseFloat(amount);
+      if (!isNaN(parsed)) {
+        return parsed;
+      }
+    }
+
+    // ÖKOBAUDAT stores values in other.anies with module breakdown
+    // Sum A1-A3 + C3 or C4 (end-of-life) for consistency with KBOB "Total"
+    const other = bestResult?.other || {};
+    const anies = Array.isArray(other?.anies) ? other.anies : [];
+
+    let gwpSum = 0;
+    let foundValues = false;
+    let hasA1A3Combined = false;
+    let a1a3CombinedValue = 0;
+    let a1Value = 0;
+    let a2Value = 0;
+    let a3Value = 0;
+    let c3Value = 0;
+    let c4Value = 0;
+    let hasC3 = false;
+    let hasC4 = false;
+
+    for (const entry of anies) {
+      if (typeof entry !== "object") continue;
+      const moduleCode = entry?.module || "";
+      const val = parseFloat(entry?.value);
+      if (isNaN(val)) continue;
+
+      if (moduleCode === "A1-A3") {
+        hasA1A3Combined = true;
+        a1a3CombinedValue = val;
+        foundValues = true;
+      } else if (moduleCode === "A1") {
+        a1Value = val;
+      } else if (moduleCode === "A2") {
+        a2Value = val;
+      } else if (moduleCode === "A3") {
+        a3Value = val;
+      } else if (moduleCode === "C3") {
+        hasC3 = true;
+        c3Value = val;
+      } else if (moduleCode === "C4") {
+        hasC4 = true;
+        c4Value = val;
+      }
+    }
+
+    // Use A1-A3 combined if available, otherwise sum individual
+    if (hasA1A3Combined) {
+      gwpSum += a1a3CombinedValue;
+    } else if (a1Value !== 0 || a2Value !== 0 || a3Value !== 0) {
+      gwpSum += a1Value + a2Value + a3Value;
+      foundValues = true;
+    }
+
+    // Add C3 or C4 (prefer C3 if both available)
+    if (hasC3) {
+      gwpSum += c3Value;
+    } else if (hasC4) {
+      gwpSum += c4Value;
+    }
+
+    return foundValues ? gwpSum : null;
+  }
+
+  /**
+   * Normalize GWP from declared unit to per-kg
+   */
+  private normalizeGwpToPerKg(
+    gwpDeclared: number,
+    declaredUnit: string,
+    density: number
+  ): number | null {
+    const unit = declaredUnit.toLowerCase().trim();
+
+    if (unit === "kg") {
+      return gwpDeclared;
+    } else if (unit === "m3" || unit === "m³" || unit === "cbm") {
+      if (!density || density <= 0) {
+        return null;
+      }
+      return gwpDeclared / density;
+    } else if (unit === "m2" || unit === "m²" || unit === "qm") {
+      // Area-based units need grammage (kg/m²) - skip
+      return null;
+    } else if (unit === "m" || unit === "lfm" || unit === "lm") {
+      // Linear meter - skip
+      return null;
+    } else if (
+      unit === "stk" ||
+      unit === "stück" ||
+      unit === "pcs" ||
+      unit === "piece"
+    ) {
+      // Per piece - skip
+      return null;
+    }
+
+    return null;
+  }
+
+  /**
+   * Fetch a single material's full EPD data
+   */
+  private async fetchEpdData(uuid: string): Promise<any | null> {
+    const url = `${OKOBAUDAT_CONFIG.baseUrl}/datastocks/${OKOBAUDAT_CONFIG.datastockId}/processes/${uuid}`;
+    const params = new URLSearchParams({
+      format: "json",
+      view: "extended",
+    });
+
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(
+        () => controller.abort(),
+        OKOBAUDAT_CONFIG.requestTimeout
+      );
+
+      const response = await fetch(`${url}?${params}`, {
+        signal: controller.signal,
+        headers: {
+          Accept: "application/json",
+        },
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        logger.debug(`[ÖKOBAUDAT LCA] Failed to fetch EPD ${uuid}: ${response.status}`);
+        return null;
+      }
+
+      return await response.json();
+    } catch (error) {
+      if ((error as Error).name === "AbortError") {
+        logger.debug(`[ÖKOBAUDAT LCA] Timeout fetching EPD ${uuid}`);
+      } else {
+        logger.debug(`[ÖKOBAUDAT LCA] Error fetching EPD ${uuid}:`, error);
+      }
+      return null;
+    }
+  }
+
+  /**
+   * Extract name from process search result
+   */
+  private extractNameFromProcess(process: OkobaudatProcessInfo): string {
+    const name = process.name;
+
+    if (typeof name === "string") {
+      return name;
+    }
+
+    if (Array.isArray(name)) {
+      // Prefer German, then English
+      for (const entry of name) {
+        if (entry?.lang === "de" && entry?.value) {
+          return entry.value;
+        }
+      }
+      for (const entry of name) {
+        if (entry?.lang === "en" && entry?.value) {
+          return entry.value;
+        }
+      }
+      if (name[0]?.value) {
+        return name[0].value;
+      }
+    }
+
+    return process.uuid || "Unknown";
+  }
+
+  /**
+   * Transform database record to unified format
+   */
+  private toUnifiedFormat(material: IOkobaudatMaterial): LcaMaterialData {
+    return {
+      id: createLcaMaterialId("okobaudat", material.uuid),
+      sourceId: material.uuid,
+      source: "okobaudat",
+      name: material.name,
+      nameDE: material.nameDE,
+      category: material.category,
+      density: material.density,
+      declaredUnit: material.declaredUnit,
+      gwp: material.gwpTotal,
+      ubp: null, // ÖKOBAUDAT doesn't have UBP
+      penre: material.penreTotal ?? null,
+      version: material.version,
+      lastUpdated: material.lastUpdated,
+      epdUrl: material.epdUrl,
+      validUntil: material.validUntil,
+    };
+  }
+
+  /**
+   * Transform database record to search result format
+   */
+  private toSearchResult(material: IOkobaudatMaterial): LcaMaterialSearchResult {
+    return {
+      id: createLcaMaterialId("okobaudat", material.uuid),
+      sourceId: material.uuid,
+      source: "okobaudat",
+      name: material.name,
+      nameDE: material.nameDE,
+      category: material.category,
+      density: material.density,
+      gwp: material.gwpTotal,
+      ubp: null,
+      penre: material.penreTotal ?? null,
+    };
+  }
+
+  /**
+   * Search materials via ÖKOBAUDAT API (live search)
+   */
+  async search(query: string, limit: number = 50): Promise<LcaMaterialSearchResult[]> {
+    if (!query || query.length < 2) {
+      return [];
+    }
+
+    // First, try to search in cached database
+    await connectToDatabase();
+
+    const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const cachedResults = await OkobaudatMaterial.find({
+      $or: [
+        { name: { $regex: escapedQuery, $options: "i" } },
+        { nameDE: { $regex: escapedQuery, $options: "i" } },
+      ],
+      gwpTotal: { $exists: true, $ne: null },
+      density: { $exists: true, $gt: 0 },
+    })
+      .limit(limit)
+      .sort({ name: 1 })
+      .lean();
+
+    if (cachedResults.length >= limit) {
+      return cachedResults.map((m) => this.toSearchResult(m));
+    }
+
+    // If not enough cached results, search API
+    const url = `${OKOBAUDAT_CONFIG.baseUrl}/datastocks/${OKOBAUDAT_CONFIG.datastockId}/processes`;
+    const params = new URLSearchParams({
+      format: "json",
+      search: "true",
+      name: query,
+      compliance: OKOBAUDAT_CONFIG.complianceA2,
+      pageSize: String(limit),
+    });
+
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(
+        () => controller.abort(),
+        OKOBAUDAT_CONFIG.requestTimeout
+      );
+
+      const response = await fetch(`${url}?${params}`, {
+        signal: controller.signal,
+        headers: {
+          Accept: "application/json",
+        },
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        logger.warn(`[ÖKOBAUDAT LCA] Search API error: ${response.status}`);
+        return cachedResults.map((m) => this.toSearchResult(m));
+      }
+
+      const data: OkobaudatSearchResponse = await response.json();
+      const processes = data?.data || [];
+
+      if (!Array.isArray(processes)) {
+        return cachedResults.map((m) => this.toSearchResult(m));
+      }
+
+      // Fetch full EPD data for each process (in parallel, limited concurrency)
+      const results: LcaMaterialSearchResult[] = [];
+      const batchSize = 5;
+
+      for (let i = 0; i < Math.min(processes.length, limit); i += batchSize) {
+        const batch = processes.slice(i, i + batchSize);
+
+        const batchPromises = batch.map(async (process) => {
+          const uuid = process.uuid;
+          if (!uuid) return null;
+
+          // Check cache first
+          const cached = await OkobaudatMaterial.findOne({ uuid }).lean();
+          if (cached) {
+            return this.toSearchResult(cached);
+          }
+
+          // Fetch full EPD data
+          const epdData = await this.fetchEpdData(uuid);
+          if (!epdData) return null;
+
+          const refExchange = this.extractReferenceExchange(epdData);
+          if (!refExchange) return null;
+
+          const density = this.extractDensity(refExchange);
+          if (!density || density <= 0) return null;
+
+          const gwpDeclared = this.extractGwpTotal(epdData);
+          if (gwpDeclared === null) return null;
+
+          const declaredUnit = this.extractDeclaredUnit(refExchange);
+          const gwpTotal = this.normalizeGwpToPerKg(
+            gwpDeclared,
+            declaredUnit,
+            density
+          );
+
+          if (gwpTotal === null) return null;
+
+          const name = this.extractEpdName(epdData);
+
+          // Cache the result
+          const materialData: IOkobaudatMaterial = {
+            uuid,
+            name,
+            nameDE: name,
+            density,
+            declaredUnit,
+            gwpDeclared,
+            gwpTotal,
+            lastUpdated: new Date(),
+          };
+
+          try {
+            await OkobaudatMaterial.findOneAndUpdate(
+              { uuid },
+              { $set: materialData },
+              { upsert: true }
+            );
+          } catch {
+            // Ignore cache errors
+          }
+
+          return this.toSearchResult(materialData);
+        });
+
+        const batchResults = await Promise.all(batchPromises);
+        results.push(
+          ...batchResults.filter(
+            (r): r is LcaMaterialSearchResult => r !== null
+          )
+        );
+      }
+
+      // Sort: "Durchschnitt DE" (German average) materials first
+      results.sort((a, b) => {
+        const aName = a.name.toLowerCase();
+        const bName = b.name.toLowerCase();
+        const aIsDurchschnitt = aName.includes("durchschnitt");
+        const bIsDurchschnitt = bName.includes("durchschnitt");
+        const aIsDE = aName.includes("de)") || aName.includes("de ");
+        const bIsDE = bName.includes("de)") || bName.includes("de ");
+
+        if (aIsDurchschnitt && aIsDE && !(bIsDurchschnitt && bIsDE)) return -1;
+        if (bIsDurchschnitt && bIsDE && !(aIsDurchschnitt && aIsDE)) return 1;
+        if (aIsDurchschnitt && !bIsDurchschnitt) return -1;
+        if (bIsDurchschnitt && !aIsDurchschnitt) return 1;
+        return a.name.localeCompare(b.name);
+      });
+
+      return results;
+    } catch (error) {
+      if ((error as Error).name === "AbortError") {
+        logger.warn("[ÖKOBAUDAT LCA] Search request timed out");
+      } else {
+        logger.error("[ÖKOBAUDAT LCA] Search error:", error);
+      }
+      return cachedResults.map((m) => this.toSearchResult(m));
+    }
+  }
+
+  /**
+   * Get a single material by ID
+   */
+  async getById(id: string): Promise<LcaMaterialData | null> {
+    const prefix = "OKOBAU_";
+    if (!id.startsWith(prefix)) {
+      return null;
+    }
+    const uuid = id.slice(prefix.length);
+
+    // Check memory cache
+    if (this.cache.has(id)) {
+      return this.cache.get(id)!;
+    }
+
+    await connectToDatabase();
+
+    // Check database cache
+    const cached = await OkobaudatMaterial.findOne({ uuid }).lean();
+    if (cached) {
+      const material = this.toUnifiedFormat(cached);
+      this.cache.set(id, material);
+      return material;
+    }
+
+    // Fetch from API
+    const epdData = await this.fetchEpdData(uuid);
+    if (!epdData) {
+      return null;
+    }
+
+    const refExchange = this.extractReferenceExchange(epdData);
+    if (!refExchange) {
+      return null;
+    }
+
+    const density = this.extractDensity(refExchange);
+    if (!density || density <= 0) {
+      throw new Error(`Material ${uuid} has no valid density`);
+    }
+
+    const gwpDeclared = this.extractGwpTotal(epdData);
+    if (gwpDeclared === null) {
+      throw new Error(`Material ${uuid} has no GWP-total in LCIAResults`);
+    }
+
+    const declaredUnit = this.extractDeclaredUnit(refExchange);
+    const gwpTotal = this.normalizeGwpToPerKg(gwpDeclared, declaredUnit, density);
+
+    if (gwpTotal === null) {
+      throw new Error(
+        `Cannot normalize GWP from ${declaredUnit} to kg for material ${uuid}`
+      );
+    }
+
+    const name = this.extractEpdName(epdData);
+
+    const materialData: IOkobaudatMaterial = {
+      uuid,
+      name,
+      nameDE: name,
+      density,
+      declaredUnit,
+      gwpDeclared,
+      gwpTotal,
+      lastUpdated: new Date(),
+    };
+
+    // Cache in database
+    try {
+      await OkobaudatMaterial.findOneAndUpdate(
+        { uuid },
+        { $set: materialData },
+        { upsert: true }
+      );
+    } catch {
+      // Ignore cache errors
+    }
+
+    const material = this.toUnifiedFormat(materialData);
+    this.cache.set(id, material);
+    return material;
+  }
+
+  /**
+   * Get all materials from cache
+   * Note: ÖKOBAUDAT doesn't have a bulk export endpoint, so we return cached results
+   */
+  async getAll(): Promise<LcaMaterialData[]> {
+    await connectToDatabase();
+
+    const materials = (await OkobaudatMaterial.findValidMaterials().lean()) as unknown as IOkobaudatMaterial[];
+    return materials.map((m) => this.toUnifiedFormat(m));
+  }
+
+  /**
+   * Sync is not fully supported for ÖKOBAUDAT (no bulk export API)
+   * This method returns the current cache status
+   */
+  async sync(): Promise<{ synced: number; errors: number }> {
+    logger.info(
+      "[ÖKOBAUDAT LCA] ÖKOBAUDAT doesn't support bulk sync - materials are cached on-demand during search"
+    );
+
+    await connectToDatabase();
+    const count = await OkobaudatMaterial.countDocuments({
+      gwpTotal: { $exists: true, $ne: null },
+    });
+
+    return { synced: count, errors: 0 };
+  }
+}
+
+// Singleton instance
+let _instance: OkobaudatLcaService | null = null;
+
+export function getOkobaudatLcaService(): OkobaudatLcaService {
+  if (!_instance) {
+    _instance = new OkobaudatLcaService();
+  }
+  return _instance;
+}

--- a/src/lib/services/lca/openepd-lca-service.ts
+++ b/src/lib/services/lca/openepd-lca-service.ts
@@ -1,0 +1,485 @@
+/**
+ * OpenEPD LCA Service
+ * Implements ILcaDataService for Building Transparency EC3/OpenEPD database
+ * Requires API key from EC3 account (free registration)
+ */
+
+import { logger } from "@/lib/logger";
+import { connectToDatabase } from "@/lib/mongodb";
+import { OpenEpdMaterial, type IOpenEpdMaterial } from "@/models/openepd";
+import type {
+  ILcaDataService,
+  LcaDataSource,
+  LcaIndicator,
+  LcaMaterialData,
+  LcaMaterialSearchResult,
+} from "@/lib/types/lca";
+import { createLcaMaterialId } from "@/lib/types/lca";
+
+// Configuration
+const OPENEPD_CONFIG = {
+  // EC3 API base URL
+  baseUrl:
+    process.env.OPENEPD_BASE_URL || "https://openepd.buildingtransparency.org",
+  apiKey: process.env.OPENEPD_API_KEY,
+  syncInterval: 7 * 24 * 60 * 60 * 1000, // 7 days
+  requestTimeout: 30000, // 30 seconds
+};
+
+interface OpenEpdSearchResult {
+  id: string;
+  name?: string;
+  product_name?: string;
+  manufacturer?: { name?: string };
+  category?: { name?: string };
+  declared_unit?: string;
+  gwp?: {
+    a1a2a3?: number;
+    c?: number;
+    total?: number;
+  };
+  plant_or_group?: {
+    owned_by?: { name?: string };
+  };
+  valid_until?: string;
+  program_operator?: { name?: string };
+}
+
+interface OpenEpdSearchResponse {
+  results?: OpenEpdSearchResult[];
+  count?: number;
+  next?: string;
+}
+
+export class OpenEpdLcaService implements ILcaDataService {
+  readonly source: LcaDataSource = "openepd";
+  readonly displayName = "OpenEPD / EC3 (Global)";
+  readonly countryFlag = "🌍";
+
+  private cache: Map<string, LcaMaterialData> = new Map();
+
+  /**
+   * Check if API is configured
+   */
+  isConfigured(): boolean {
+    return Boolean(OPENEPD_CONFIG.apiKey);
+  }
+
+  getAvailableIndicators(): LcaIndicator[] {
+    // OpenEPD focuses primarily on GWP
+    return ["gwp"];
+  }
+
+  /**
+   * Check if cache needs refresh
+   */
+  async needsRefresh(): Promise<boolean> {
+    if (!this.isConfigured()) {
+      return false;
+    }
+
+    await connectToDatabase();
+
+    const latestMaterial = await OpenEpdMaterial.findOne({
+      lastUpdated: { $exists: true },
+    })
+      .sort({ lastUpdated: -1 })
+      .lean();
+
+    if (!latestMaterial || !latestMaterial.lastUpdated) {
+      logger.info("[OpenEPD LCA] No cached materials found");
+      return true;
+    }
+
+    const age = Date.now() - new Date(latestMaterial.lastUpdated).getTime();
+    return age > OPENEPD_CONFIG.syncInterval;
+  }
+
+  /**
+   * Get authorization headers
+   */
+  private getHeaders(): HeadersInit {
+    if (!OPENEPD_CONFIG.apiKey) {
+      throw new Error("OpenEPD API key not configured. Set OPENEPD_API_KEY environment variable.");
+    }
+
+    return {
+      Authorization: `Bearer ${OPENEPD_CONFIG.apiKey}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    };
+  }
+
+  /**
+   * Normalize GWP to per-kg value
+   * OpenEPD provides GWP per declared unit
+   */
+  private normalizeGwpToPerKg(
+    gwpDeclared: number,
+    declaredUnit: string,
+    density?: number
+  ): number | null {
+    const unit = (declaredUnit || "").toLowerCase().trim();
+
+    // Already per kg
+    if (unit === "kg" || unit === "1 kg") {
+      return gwpDeclared;
+    }
+
+    // Per m³ - need density
+    if (unit === "m3" || unit === "1 m3" || unit.includes("m³")) {
+      if (!density || density <= 0) {
+        // Without density, we can't normalize - return null
+        return null;
+      }
+      return gwpDeclared / density;
+    }
+
+    // Per tonne/metric ton
+    if (unit === "t" || unit === "1 t" || unit === "tonne" || unit === "metric ton") {
+      return gwpDeclared / 1000;
+    }
+
+    // Per m² - area-based, skip (would need grammage)
+    if (unit === "m2" || unit.includes("m²")) {
+      return null;
+    }
+
+    // For other units we can't reliably normalize, return the value as-is
+    // with a warning in logs
+    logger.debug(`[OpenEPD LCA] Unknown unit '${declaredUnit}', using GWP as-is`);
+    return gwpDeclared;
+  }
+
+  /**
+   * Transform API result to database format
+   */
+  private transformApiResult(result: OpenEpdSearchResult): IOpenEpdMaterial | null {
+    const id = result.id;
+    if (!id) return null;
+
+    // Extract GWP values
+    const gwpA1A2A3 = result.gwp?.a1a2a3;
+    const gwpC = result.gwp?.c;
+    let gwpDeclared = result.gwp?.total;
+
+    // Calculate total if not provided
+    if (gwpDeclared === undefined || gwpDeclared === null) {
+      if (gwpA1A2A3 !== undefined && gwpA1A2A3 !== null) {
+        gwpDeclared = gwpA1A2A3 + (gwpC || 0);
+      } else {
+        return null; // No GWP data
+      }
+    }
+
+    const declaredUnit = result.declared_unit || "kg";
+    const name =
+      result.product_name ||
+      result.name ||
+      result.plant_or_group?.owned_by?.name ||
+      "Unknown";
+
+    // Try to normalize to per-kg
+    // Note: OpenEPD doesn't always provide density, so we may not be able to normalize
+    const gwpTotal = this.normalizeGwpToPerKg(gwpDeclared, declaredUnit);
+
+    if (gwpTotal === null) {
+      return null;
+    }
+
+    return {
+      id,
+      name,
+      productName: result.product_name,
+      manufacturerName:
+        result.manufacturer?.name ||
+        result.plant_or_group?.owned_by?.name,
+      category: result.category?.name,
+      declaredUnit,
+      gwpDeclared,
+      gwpA1A2A3,
+      gwpC,
+      gwpTotal,
+      programOperator: result.program_operator?.name,
+      validUntil: result.valid_until ? new Date(result.valid_until) : undefined,
+      lastUpdated: new Date(),
+    };
+  }
+
+  /**
+   * Transform database record to unified format
+   */
+  private toUnifiedFormat(material: IOpenEpdMaterial): LcaMaterialData {
+    return {
+      id: createLcaMaterialId("openepd", material.id),
+      sourceId: material.id,
+      source: "openepd",
+      name: material.name,
+      category: material.category,
+      density: material.density || 0,
+      declaredUnit: material.declaredUnit,
+      gwp: material.gwpTotal,
+      ubp: null, // OpenEPD doesn't have UBP
+      penre: null, // OpenEPD doesn't always have PENRE
+      validUntil: material.validUntil,
+      lastUpdated: material.lastUpdated,
+      epdUrl: material.epdUrl,
+    };
+  }
+
+  /**
+   * Transform database record to search result format
+   */
+  private toSearchResult(material: IOpenEpdMaterial): LcaMaterialSearchResult {
+    return {
+      id: createLcaMaterialId("openepd", material.id),
+      sourceId: material.id,
+      source: "openepd",
+      name: material.name,
+      category: material.category,
+      density: material.density || null,
+      gwp: material.gwpTotal,
+      ubp: null,
+      penre: null,
+    };
+  }
+
+  /**
+   * Search materials via OpenEPD API
+   */
+  async search(query: string, limit: number = 50): Promise<LcaMaterialSearchResult[]> {
+    if (!query || query.length < 2) {
+      return [];
+    }
+
+    if (!this.isConfigured()) {
+      logger.warn("[OpenEPD LCA] API key not configured, searching cache only");
+      return this.searchCache(query, limit);
+    }
+
+    // First check cache
+    await connectToDatabase();
+    const cachedResults = await this.searchCache(query, Math.min(limit, 20));
+
+    // Search API
+    const url = new URL(`${OPENEPD_CONFIG.baseUrl}/api/epds`);
+    url.searchParams.set("q", query);
+    url.searchParams.set("page_size", String(limit));
+
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(
+        () => controller.abort(),
+        OPENEPD_CONFIG.requestTimeout
+      );
+
+      const response = await fetch(url.toString(), {
+        signal: controller.signal,
+        headers: this.getHeaders(),
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        if (response.status === 401 || response.status === 403) {
+          logger.error("[OpenEPD LCA] Authentication failed - check API key");
+        } else {
+          logger.warn(`[OpenEPD LCA] Search API error: ${response.status}`);
+        }
+        return cachedResults;
+      }
+
+      const data: OpenEpdSearchResponse = await response.json();
+      const results = data?.results || [];
+
+      if (!Array.isArray(results)) {
+        return cachedResults;
+      }
+
+      // Transform and cache results
+      const materials: LcaMaterialSearchResult[] = [];
+
+      for (const result of results) {
+        const material = this.transformApiResult(result);
+        if (!material) continue;
+
+        // Cache in database
+        try {
+          await OpenEpdMaterial.findOneAndUpdate(
+            { id: material.id },
+            { $set: material },
+            { upsert: true }
+          );
+        } catch {
+          // Ignore cache errors
+        }
+
+        materials.push(this.toSearchResult(material));
+      }
+
+      // Combine with cached results (deduplicated)
+      const seenIds = new Set(materials.map((m) => m.id));
+      for (const cached of cachedResults) {
+        if (!seenIds.has(cached.id)) {
+          materials.push(cached);
+        }
+      }
+
+      return materials.slice(0, limit);
+    } catch (error) {
+      if ((error as Error).name === "AbortError") {
+        logger.warn("[OpenEPD LCA] Search request timed out");
+      } else {
+        logger.error("[OpenEPD LCA] Search error:", error);
+      }
+      return cachedResults;
+    }
+  }
+
+  /**
+   * Search cached materials
+   */
+  private async searchCache(
+    query: string,
+    limit: number
+  ): Promise<LcaMaterialSearchResult[]> {
+    await connectToDatabase();
+
+    const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const results = await OpenEpdMaterial.find({
+      $or: [
+        { name: { $regex: escapedQuery, $options: "i" } },
+        { productName: { $regex: escapedQuery, $options: "i" } },
+        { category: { $regex: escapedQuery, $options: "i" } },
+      ],
+      gwpTotal: { $exists: true, $ne: null },
+    })
+      .limit(limit)
+      .sort({ name: 1 })
+      .lean();
+
+    return results.map((m) => this.toSearchResult(m));
+  }
+
+  /**
+   * Get a single material by ID
+   */
+  async getById(id: string): Promise<LcaMaterialData | null> {
+    const prefix = "OPENEPD_";
+    if (!id.startsWith(prefix)) {
+      return null;
+    }
+    const sourceId = id.slice(prefix.length);
+
+    // Check memory cache
+    if (this.cache.has(id)) {
+      return this.cache.get(id)!;
+    }
+
+    await connectToDatabase();
+
+    // Check database cache
+    const cached = await OpenEpdMaterial.findOne({ id: sourceId }).lean();
+    if (cached) {
+      const material = this.toUnifiedFormat(cached);
+      this.cache.set(id, material);
+      return material;
+    }
+
+    // Fetch from API if configured
+    if (!this.isConfigured()) {
+      return null;
+    }
+
+    const url = `${OPENEPD_CONFIG.baseUrl}/api/epds/${sourceId}`;
+
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(
+        () => controller.abort(),
+        OPENEPD_CONFIG.requestTimeout
+      );
+
+      const response = await fetch(url, {
+        signal: controller.signal,
+        headers: this.getHeaders(),
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        logger.warn(`[OpenEPD LCA] Failed to fetch EPD ${sourceId}: ${response.status}`);
+        return null;
+      }
+
+      const result: OpenEpdSearchResult = await response.json();
+      const material = this.transformApiResult(result);
+
+      if (!material) {
+        return null;
+      }
+
+      // Cache in database
+      try {
+        await OpenEpdMaterial.findOneAndUpdate(
+          { id: material.id },
+          { $set: material },
+          { upsert: true }
+        );
+      } catch {
+        // Ignore cache errors
+      }
+
+      const unified = this.toUnifiedFormat(material);
+      this.cache.set(id, unified);
+      return unified;
+    } catch (error) {
+      logger.error(`[OpenEPD LCA] Error fetching EPD ${sourceId}:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Get all materials from cache
+   */
+  async getAll(): Promise<LcaMaterialData[]> {
+    await connectToDatabase();
+
+    const materials = (await OpenEpdMaterial.findValidMaterials().lean()) as unknown as IOpenEpdMaterial[];
+    return materials.map((m) => this.toUnifiedFormat(m));
+  }
+
+  /**
+   * Sync materials from OpenEPD
+   * Note: OpenEPD doesn't have a bulk export, so this returns cache status
+   */
+  async sync(): Promise<{ synced: number; errors: number }> {
+    if (!this.isConfigured()) {
+      logger.warn(
+        "[OpenEPD LCA] API key not configured - set OPENEPD_API_KEY to enable sync"
+      );
+      return { synced: 0, errors: 0 };
+    }
+
+    logger.info(
+      "[OpenEPD LCA] OpenEPD materials are cached on-demand during search"
+    );
+
+    await connectToDatabase();
+    const count = await OpenEpdMaterial.countDocuments({
+      gwpTotal: { $exists: true, $ne: null },
+    });
+
+    return { synced: count, errors: 0 };
+  }
+}
+
+// Singleton instance
+let _instance: OpenEpdLcaService | null = null;
+
+export function getOpenEpdLcaService(): OpenEpdLcaService {
+  if (!_instance) {
+    _instance = new OpenEpdLcaService();
+  }
+  return _instance;
+}

--- a/src/lib/types/lca.ts
+++ b/src/lib/types/lca.ts
@@ -1,0 +1,240 @@
+/**
+ * Types and interfaces for multi-source LCA (Life Cycle Assessment) data
+ * Supports KBOB (Switzerland), ÖKOBAUDAT (Germany), and OpenEPD (Global)
+ */
+
+/**
+ * Supported LCA data sources
+ */
+export type LcaDataSource = 'kbob' | 'okobaudat' | 'openepd';
+
+/**
+ * Available environmental indicators
+ */
+export type LcaIndicator = 'gwp' | 'ubp' | 'penre';
+
+/**
+ * Unified material data structure for all LCA data sources
+ * All environmental indicators are normalized to per-kg values
+ */
+export interface LcaMaterialData {
+  // Universal identifiers
+  /** Source-prefixed ID: "KBOB_xxx", "OKOBAU_xxx", "OPENEPD_xxx" */
+  id: string;
+  /** Original ID from source (uuid, etc.) */
+  sourceId: string;
+  /** Data source identifier */
+  source: LcaDataSource;
+
+  // Display information
+  /** Primary display name */
+  name: string;
+  /** German name (if available) */
+  nameDE?: string;
+  /** French name (if available) */
+  nameFR?: string;
+  /** Material category/group */
+  category?: string;
+
+  // Physical properties
+  /** Density in kg/m³ (required for calculations) */
+  density: number;
+  /** Declared unit from source (m³, kg, m², etc.) */
+  declaredUnit: string;
+
+  // Environmental indicators (per kg, normalized)
+  /** Global Warming Potential (kg CO₂-eq/kg) - available in all sources */
+  gwp: number;
+  /** Umweltbelastungspunkte (Swiss ecological scarcity) - KBOB only */
+  ubp?: number | null;
+  /** Primary Energy Non-Renewable (MJ/kg) */
+  penre?: number | null;
+
+  // Metadata
+  /** EPD validity date */
+  validUntil?: Date;
+  /** Data quality indicator */
+  dataQuality?: string;
+  /** Link to original EPD document */
+  epdUrl?: string;
+  /** API version or database version */
+  version?: string;
+  /** Last sync/update timestamp */
+  lastUpdated?: Date;
+}
+
+/**
+ * Material search result for UI display (lightweight version)
+ */
+export interface LcaMaterialSearchResult {
+  id: string;
+  sourceId: string;
+  source: LcaDataSource;
+  name: string;
+  nameDE?: string;
+  category?: string;
+  density: number | null;
+  gwp: number | null;
+  ubp?: number | null;
+  penre?: number | null;
+}
+
+/**
+ * LCA match stored on a material
+ */
+export interface LcaMatch {
+  /** Data source: kbob, okobaudat, openepd */
+  source: LcaDataSource;
+  /** Source-prefixed ID (e.g., "KBOB_uuid", "OKOBAU_uuid") */
+  materialId: string;
+  /** Original source UUID/ID */
+  sourceId: string;
+  /** Cached material name for display */
+  name: string;
+  /** When the match was created */
+  matchedAt: Date;
+  /** Cached indicator values at match time */
+  indicators?: {
+    gwp: number;
+    ubp?: number | null;
+    penre?: number | null;
+  };
+}
+
+/**
+ * Service interface for LCA data providers
+ */
+export interface ILcaDataService {
+  /** Data source identifier */
+  readonly source: LcaDataSource;
+  /** Human-readable display name */
+  readonly displayName: string;
+  /** Country/region flag for display */
+  readonly countryFlag: string;
+
+  /**
+   * Search materials by name/query
+   * @param query Search term (min 2 characters)
+   * @param limit Maximum results (default: 50)
+   */
+  search(query: string, limit?: number): Promise<LcaMaterialSearchResult[]>;
+
+  /**
+   * Get a single material by its source-prefixed ID
+   * @param id Material ID (e.g., "KBOB_uuid")
+   */
+  getById(id: string): Promise<LcaMaterialData | null>;
+
+  /**
+   * Get all valid materials from cache/database
+   */
+  getAll(): Promise<LcaMaterialData[]>;
+
+  /**
+   * Sync materials from external API to local cache
+   */
+  sync(): Promise<{ synced: number; errors: number }>;
+
+  /**
+   * Get list of indicators available from this source
+   */
+  getAvailableIndicators(): LcaIndicator[];
+
+  /**
+   * Check if cache needs refresh
+   */
+  needsRefresh(): Promise<boolean>;
+}
+
+/**
+ * Metadata about an LCA data source
+ */
+export interface LcaDataSourceInfo {
+  id: LcaDataSource;
+  name: string;
+  displayName: string;
+  countryFlag: string;
+  country: string;
+  description: string;
+  indicators: LcaIndicator[];
+  /** Whether API key is required */
+  requiresApiKey: boolean;
+  /** Whether this source is currently configured/available */
+  isConfigured: boolean;
+  /** External documentation URL */
+  docsUrl?: string;
+}
+
+/**
+ * Configuration for LCA data sources
+ */
+export const LCA_SOURCE_CONFIG: Record<LcaDataSource, Omit<LcaDataSourceInfo, 'isConfigured'>> = {
+  kbob: {
+    id: 'kbob',
+    name: 'KBOB',
+    displayName: 'KBOB (Switzerland)',
+    countryFlag: '🇨🇭',
+    country: 'Switzerland',
+    description: 'Swiss construction materials database with GWP, UBP (ecological scarcity), and primary energy data.',
+    indicators: ['gwp', 'ubp', 'penre'],
+    requiresApiKey: true,
+    docsUrl: 'https://www.kbob.admin.ch/',
+  },
+  okobaudat: {
+    id: 'okobaudat',
+    name: 'ÖKOBAUDAT',
+    displayName: 'ÖKOBAUDAT (Germany)',
+    countryFlag: '🇩🇪',
+    country: 'Germany',
+    description: 'German national EPD database for construction products. Free API access.',
+    indicators: ['gwp', 'penre'],
+    requiresApiKey: false,
+    docsUrl: 'https://www.oekobaudat.de/',
+  },
+  openepd: {
+    id: 'openepd',
+    name: 'OpenEPD',
+    displayName: 'OpenEPD / EC3 (Global)',
+    countryFlag: '🌍',
+    country: 'Global',
+    description: 'Building Transparency EC3 database with global EPD data. Requires free API key.',
+    indicators: ['gwp'],
+    requiresApiKey: true,
+    docsUrl: 'https://docs.open-epd-forum.org/',
+  },
+};
+
+/**
+ * ID prefix constants for each data source
+ */
+export const LCA_ID_PREFIX: Record<LcaDataSource, string> = {
+  kbob: 'KBOB_',
+  okobaudat: 'OKOBAU_',
+  openepd: 'OPENEPD_',
+};
+
+/**
+ * Parse a source-prefixed material ID
+ * @param materialId e.g., "KBOB_abc-123"
+ * @returns { source, sourceId } or null if invalid
+ */
+export function parseLcaMaterialId(materialId: string): { source: LcaDataSource; sourceId: string } | null {
+  for (const [source, prefix] of Object.entries(LCA_ID_PREFIX)) {
+    if (materialId.startsWith(prefix)) {
+      return {
+        source: source as LcaDataSource,
+        sourceId: materialId.slice(prefix.length),
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Create a source-prefixed material ID
+ * @param source Data source
+ * @param sourceId Original ID from source
+ */
+export function createLcaMaterialId(source: LcaDataSource, sourceId: string): string {
+  return `${LCA_ID_PREFIX[source]}${sourceId}`;
+}

--- a/src/lib/utils/lca-indicators.ts
+++ b/src/lib/utils/lca-indicators.ts
@@ -1,0 +1,217 @@
+/**
+ * Utility functions for extracting environmental indicators from LCA materials
+ * Supports multiple data sources: KBOB, ÖKOBAUDAT, OpenEPD
+ */
+
+import type { LcaDataSource, LcaMaterialSearchResult, LcaMaterialData, LcaMatch } from "@/lib/types/lca";
+
+/**
+ * Generic LCA material interface for indicator extraction
+ */
+interface LcaMaterialLike {
+  // Unified format fields
+  gwp?: number | null;
+  ubp?: number | null;
+  penre?: number | null;
+  density?: number | null;
+  source?: LcaDataSource;
+
+  // KBOB-specific fields (for backward compatibility)
+  gwpTotal?: number | null;
+  ubp21Total?: number | null;
+  primaryEnergyNonRenewableTotal?: number | null;
+}
+
+/**
+ * Check if an LCA material has valid environmental indicators
+ */
+export function isValidLcaMaterial(
+  material: LcaMaterialLike | null | undefined,
+  source?: LcaDataSource
+): boolean {
+  if (!material) return false;
+
+  // Get GWP value (required for all sources)
+  const gwp = material.gwp ?? material.gwpTotal;
+  const hasValidGwp = gwp !== null && gwp !== undefined;
+
+  // Check density
+  const hasValidDensity =
+    material.density !== null &&
+    material.density !== undefined &&
+    material.density !== 0;
+
+  // For KBOB, also require UBP and PENRE
+  if (source === "kbob" || material.ubp21Total !== undefined) {
+    const ubp = material.ubp ?? material.ubp21Total;
+    const penre = material.penre ?? material.primaryEnergyNonRenewableTotal;
+
+    const hasValidUbp = ubp !== null && ubp !== undefined;
+    const hasValidPenre = penre !== null && penre !== undefined;
+
+    // At least one indicator must be non-zero
+    const hasNonZeroIndicator =
+      (hasValidGwp && gwp !== 0) ||
+      (hasValidUbp && ubp !== 0) ||
+      (hasValidPenre && penre !== 0);
+
+    return hasValidGwp && hasValidUbp && hasValidPenre && hasNonZeroIndicator && hasValidDensity;
+  }
+
+  // For other sources, only GWP is required
+  return hasValidGwp && gwp !== 0 && hasValidDensity;
+}
+
+/**
+ * Extract GWP value from LCA material
+ */
+export function getLcaGwp(material: LcaMaterialLike | null | undefined): number {
+  if (!material) return 0;
+  return material.gwp ?? material.gwpTotal ?? 0;
+}
+
+/**
+ * Extract UBP value from LCA material (KBOB only)
+ */
+export function getLcaUbp(material: LcaMaterialLike | null | undefined): number | null {
+  if (!material) return null;
+  const value = material.ubp ?? material.ubp21Total;
+  return value ?? null;
+}
+
+/**
+ * Extract PENRE value from LCA material
+ */
+export function getLcaPenre(material: LcaMaterialLike | null | undefined): number | null {
+  if (!material) return null;
+  const value = material.penre ?? material.primaryEnergyNonRenewableTotal;
+  return value ?? null;
+}
+
+/**
+ * Extract density from LCA material
+ */
+export function getLcaDensity(material: LcaMaterialLike | null | undefined): number {
+  if (!material) return 0;
+  if (typeof material.density === "number") return material.density;
+  if (typeof material.density === "string") {
+    const parsed = parseFloat(material.density);
+    return isNaN(parsed) ? 0 : parsed;
+  }
+  return 0;
+}
+
+/**
+ * Get all environmental indicators from an LCA material
+ */
+export function getLcaIndicators(material: LcaMaterialLike | null | undefined): {
+  gwp: number;
+  ubp: number | null;
+  penre: number | null;
+} {
+  return {
+    gwp: getLcaGwp(material),
+    ubp: getLcaUbp(material),
+    penre: getLcaPenre(material),
+  };
+}
+
+/**
+ * Format GWP value for display
+ */
+export function formatGwp(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "-";
+  return `${value.toFixed(2)} kg CO₂-eq`;
+}
+
+/**
+ * Format UBP value for display
+ */
+export function formatUbp(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "-";
+  return value.toFixed(0);
+}
+
+/**
+ * Format PENRE value for display
+ */
+export function formatPenre(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "-";
+  return `${value.toFixed(1)} MJ`;
+}
+
+/**
+ * Get available indicators for a data source
+ */
+export function getSourceIndicators(source: LcaDataSource): ("gwp" | "ubp" | "penre")[] {
+  switch (source) {
+    case "kbob":
+      return ["gwp", "ubp", "penre"];
+    case "okobaudat":
+      return ["gwp", "penre"];
+    case "openepd":
+      return ["gwp"];
+    default:
+      return ["gwp"];
+  }
+}
+
+/**
+ * Check if a source has a specific indicator
+ */
+export function sourceHasIndicator(
+  source: LcaDataSource,
+  indicator: "gwp" | "ubp" | "penre"
+): boolean {
+  return getSourceIndicators(source).includes(indicator);
+}
+
+/**
+ * Get display info for an indicator
+ */
+export function getIndicatorInfo(indicator: "gwp" | "ubp" | "penre"): {
+  name: string;
+  fullName: string;
+  unit: string;
+  description: string;
+} {
+  switch (indicator) {
+    case "gwp":
+      return {
+        name: "GWP",
+        fullName: "Global Warming Potential",
+        unit: "kg CO₂-eq/kg",
+        description: "Climate change impact measured in CO₂ equivalents",
+      };
+    case "ubp":
+      return {
+        name: "UBP",
+        fullName: "Umweltbelastungspunkte",
+        unit: "UBP/kg",
+        description: "Swiss ecological scarcity method (eco-points)",
+      };
+    case "penre":
+      return {
+        name: "PENRE",
+        fullName: "Primary Energy Non-Renewable",
+        unit: "MJ/kg",
+        description: "Non-renewable primary energy consumption",
+      };
+  }
+}
+
+/**
+ * Calculate emissions for a material volume
+ */
+export function calculateEmissions(
+  volume: number,
+  density: number,
+  indicators: { gwp: number; ubp?: number | null; penre?: number | null }
+): { gwp: number; ubp: number; penre: number } {
+  const mass = volume * density;
+  return {
+    gwp: mass * indicators.gwp,
+    ubp: mass * (indicators.ubp ?? 0),
+    penre: mass * (indicators.penre ?? 0),
+  };
+}

--- a/src/models/kbob.ts
+++ b/src/models/kbob.ts
@@ -30,8 +30,13 @@ interface IKBOBMaterial {
   unit?: string;
 }
 
+// Export interface for use in other files
+export type IKBOBMaterialDocument = IKBOBMaterial & mongoose.Document & {
+  _id: mongoose.Types.ObjectId;
+};
+
 interface KBOBMaterialModel extends mongoose.Model<IKBOBMaterial> {
-  findValidMaterials(): Promise<IKBOBMaterial[]>;
+  findValidMaterials(): mongoose.Query<IKBOBMaterialDocument[], IKBOBMaterialDocument>;
 }
 
 const kbobSchema = new mongoose.Schema<IKBOBMaterial, KBOBMaterialModel>(

--- a/src/models/material.ts
+++ b/src/models/material.ts
@@ -1,5 +1,29 @@
 import mongoose from "mongoose";
 import { getGWP, getUBP, getPENRE } from "@/lib/utils/kbob-indicators";
+import type { LcaDataSource } from "@/lib/types/lca";
+
+/**
+ * LCA Match subdocument - stores reference to matched LCA material
+ * from any supported data source (KBOB, ÖKOBAUDAT, OpenEPD)
+ */
+interface ILcaMatch {
+  /** Data source: kbob, okobaudat, openepd */
+  source: LcaDataSource;
+  /** Source-prefixed ID (e.g., "KBOB_uuid", "OKOBAU_uuid", "OPENEPD_id") */
+  materialId: string;
+  /** Original source UUID/ID */
+  sourceId: string;
+  /** Cached material name for display */
+  name: string;
+  /** When the match was created */
+  matchedAt: Date;
+  /** Cached indicator values at match time */
+  indicators?: {
+    gwp: number;
+    ubp?: number | null;
+    penre?: number | null;
+  };
+}
 
 interface IMaterial {
   projectId: mongoose.Types.ObjectId;
@@ -7,9 +31,45 @@ interface IMaterial {
   category?: string;
   density?: number;
   volume?: number;
+  /** @deprecated Use lcaMatch instead. Kept for backward compatibility. */
   kbobMatchId?: mongoose.Types.ObjectId;
+  /** New multi-source LCA match reference */
+  lcaMatch?: ILcaMatch;
   lastCalculated?: Date;
 }
+
+const lcaMatchSchema = new mongoose.Schema<ILcaMatch>(
+  {
+    source: {
+      type: String,
+      enum: ["kbob", "okobaudat", "openepd"],
+      required: true,
+    },
+    materialId: {
+      type: String,
+      required: true,
+    },
+    sourceId: {
+      type: String,
+      required: true,
+    },
+    name: {
+      type: String,
+      required: true,
+    },
+    matchedAt: {
+      type: Date,
+      required: true,
+      default: Date.now,
+    },
+    indicators: {
+      gwp: { type: Number },
+      ubp: { type: Number },
+      penre: { type: Number },
+    },
+  },
+  { _id: false }
+);
 
 const materialSchema = new mongoose.Schema<IMaterial>(
   {
@@ -42,9 +102,14 @@ const materialSchema = new mongoose.Schema<IMaterial>(
         message: "Volume must be a finite number",
       },
     },
+    // Legacy field - kept for backward compatibility
     kbobMatchId: {
       type: mongoose.Schema.Types.ObjectId,
       ref: "KBOBMaterial",
+    },
+    // New multi-source LCA match
+    lcaMatch: {
+      type: lcaMatchSchema,
     },
     lastCalculated: {
       type: Date,
@@ -61,6 +126,8 @@ const materialSchema = new mongoose.Schema<IMaterial>(
 materialSchema.index({ projectId: 1, name: 1 }, { unique: true });
 materialSchema.index({ projectId: 1, createdAt: -1 });
 materialSchema.index({ kbobMatchId: 1 });
+materialSchema.index({ "lcaMatch.source": 1 });
+materialSchema.index({ "lcaMatch.materialId": 1 });
 
 // Virtual for elements using this material
 materialSchema.virtual("elements", {
@@ -96,8 +163,18 @@ materialSchema.virtual("totalVolume").get(async function () {
   return result[0]?.totalVolume || 0;
 });
 
-// Virtual for emissions factors from KBOB match
+// Virtual for emissions factors - supports both legacy kbobMatchId and new lcaMatch
 materialSchema.virtual("emissionFactors").get(function () {
+  // First check new lcaMatch with cached indicators
+  if (this.lcaMatch?.indicators) {
+    return {
+      gwp: this.lcaMatch.indicators.gwp ?? 0,
+      ubp: this.lcaMatch.indicators.ubp ?? 0,
+      penre: this.lcaMatch.indicators.penre ?? 0,
+    };
+  }
+
+  // Fall back to legacy KBOB match (requires population)
   if (!this.populated("kbobMatchId")) return null;
 
   const kbob = this.kbobMatchId as any;
@@ -111,6 +188,24 @@ materialSchema.virtual("emissionFactors").get(function () {
   };
 });
 
+// Virtual to check if material has an LCA match (from any source)
+materialSchema.virtual("hasLcaMatch").get(function () {
+  return Boolean(this.lcaMatch?.materialId || this.kbobMatchId);
+});
+
+// Virtual to get the LCA source type
+materialSchema.virtual("lcaSource").get(function () {
+  if (this.lcaMatch?.source) {
+    return this.lcaMatch.source;
+  }
+  if (this.kbobMatchId) {
+    return "kbob";
+  }
+  return null;
+});
+
 export const Material =
   mongoose.models.Material ||
   mongoose.model<IMaterial>("Material", materialSchema);
+
+export type { IMaterial, ILcaMatch };

--- a/src/models/okobaudat.ts
+++ b/src/models/okobaudat.ts
@@ -1,0 +1,95 @@
+/**
+ * MongoDB model for ÖKOBAUDAT materials cache
+ * German national EPD database for construction products
+ */
+
+import mongoose from "mongoose";
+
+export interface IOkobaudatMaterial {
+  // Primary identifier
+  uuid: string;
+
+  // Display names
+  name: string;
+  nameDE?: string;
+  nameEN?: string;
+
+  // Category/classification
+  category?: string;
+
+  // Physical properties
+  density: number; // kg/m³
+  declaredUnit: string; // m³, kg, m², etc.
+
+  // Environmental indicators (per declared unit, from API)
+  gwpDeclared?: number | null; // GWP per declared unit
+  penreDeclared?: number | null; // Primary energy non-renewable per declared unit
+
+  // Normalized indicators (per kg, calculated)
+  gwpTotal: number; // kg CO₂-eq/kg
+  penreTotal?: number | null; // MJ/kg
+
+  // Metadata
+  version?: string;
+  lastUpdated: Date;
+  epdUrl?: string;
+  validUntil?: Date;
+
+  // Raw EPD data for debugging
+  rawData?: any;
+}
+
+interface OkobaudatMaterialModel extends mongoose.Model<IOkobaudatMaterial> {
+  findValidMaterials(): mongoose.Query<IOkobaudatMaterial[], IOkobaudatMaterial>;
+}
+
+const okobaudatSchema = new mongoose.Schema<
+  IOkobaudatMaterial,
+  OkobaudatMaterialModel
+>(
+  {
+    uuid: { type: String, required: true, unique: true },
+    name: { type: String, required: true },
+    nameDE: { type: String },
+    nameEN: { type: String },
+    category: { type: String },
+    density: { type: Number, required: true },
+    declaredUnit: { type: String, required: true },
+    gwpDeclared: { type: Number },
+    penreDeclared: { type: Number },
+    gwpTotal: { type: Number, required: true },
+    penreTotal: { type: Number },
+    version: { type: String },
+    lastUpdated: { type: Date, required: true, default: Date.now },
+    epdUrl: { type: String },
+    validUntil: { type: Date },
+    rawData: { type: mongoose.Schema.Types.Mixed },
+  },
+  {
+    collection: "indicatorsOkobaudat",
+    timestamps: true,
+  }
+);
+
+// Indexes for performance
+okobaudatSchema.index({ uuid: 1 }, { unique: true });
+okobaudatSchema.index({ name: "text", nameDE: "text" });
+okobaudatSchema.index({ category: 1 });
+okobaudatSchema.index({ lastUpdated: 1 });
+okobaudatSchema.index({ gwpTotal: 1, density: 1 });
+
+// Static method to find valid materials (has GWP and density)
+okobaudatSchema.static("findValidMaterials", function () {
+  return this.find({
+    gwpTotal: { $exists: true, $ne: null },
+    density: { $exists: true, $ne: null, $gt: 0 },
+  }).sort({ name: 1 });
+});
+
+export const OkobaudatMaterial =
+  (mongoose.models.OkobaudatMaterial as OkobaudatMaterialModel) ||
+  mongoose.model<IOkobaudatMaterial, OkobaudatMaterialModel>(
+    "OkobaudatMaterial",
+    okobaudatSchema,
+    "indicatorsOkobaudat"
+  );

--- a/src/models/openepd.ts
+++ b/src/models/openepd.ts
@@ -1,0 +1,107 @@
+/**
+ * MongoDB model for OpenEPD/EC3 materials cache
+ * Global EPD database from Building Transparency
+ */
+
+import mongoose from "mongoose";
+
+export interface IOpenEpdMaterial {
+  // Primary identifier (OpenEPD uses various ID formats)
+  id: string; // OpenEPD document ID or xpd_uuid
+
+  // Display names
+  name: string;
+  productName?: string;
+  manufacturerName?: string;
+
+  // Category/classification
+  category?: string;
+  materialType?: string;
+
+  // Physical properties
+  density?: number; // kg/m³
+  declaredUnit: string; // m³, kg, m², etc.
+  declaredValue?: number; // e.g., 1 for "1 kg"
+
+  // Environmental indicators (per declared unit)
+  gwpDeclared: number; // GWP per declared unit
+  gwpA1A2A3?: number; // Production stage GWP
+  gwpC?: number; // End-of-life GWP
+
+  // Normalized indicators (per kg)
+  gwpTotal: number; // kg CO₂-eq/kg
+
+  // Metadata
+  version?: string;
+  programOperator?: string;
+  validUntil?: Date;
+  lastUpdated: Date;
+  epdUrl?: string;
+
+  // Location/scope
+  country?: string;
+  region?: string;
+
+  // Raw data for debugging
+  rawData?: any;
+}
+
+interface OpenEpdMaterialModel extends mongoose.Model<IOpenEpdMaterial> {
+  findValidMaterials(): mongoose.Query<IOpenEpdMaterial[], IOpenEpdMaterial>;
+}
+
+const openEpdSchema = new mongoose.Schema<
+  IOpenEpdMaterial,
+  OpenEpdMaterialModel
+>(
+  {
+    id: { type: String, required: true, unique: true },
+    name: { type: String, required: true },
+    productName: { type: String },
+    manufacturerName: { type: String },
+    category: { type: String },
+    materialType: { type: String },
+    density: { type: Number },
+    declaredUnit: { type: String, required: true },
+    declaredValue: { type: Number },
+    gwpDeclared: { type: Number, required: true },
+    gwpA1A2A3: { type: Number },
+    gwpC: { type: Number },
+    gwpTotal: { type: Number, required: true },
+    version: { type: String },
+    programOperator: { type: String },
+    validUntil: { type: Date },
+    lastUpdated: { type: Date, required: true, default: Date.now },
+    epdUrl: { type: String },
+    country: { type: String },
+    region: { type: String },
+    rawData: { type: mongoose.Schema.Types.Mixed },
+  },
+  {
+    collection: "indicatorsOpenEpd",
+    timestamps: true,
+  }
+);
+
+// Indexes for performance
+openEpdSchema.index({ id: 1 }, { unique: true });
+openEpdSchema.index({ name: "text", productName: "text" });
+openEpdSchema.index({ category: 1 });
+openEpdSchema.index({ lastUpdated: 1 });
+openEpdSchema.index({ gwpTotal: 1 });
+openEpdSchema.index({ country: 1, region: 1 });
+
+// Static method to find valid materials (has GWP)
+openEpdSchema.static("findValidMaterials", function () {
+  return this.find({
+    gwpTotal: { $exists: true, $ne: null },
+  }).sort({ name: 1 });
+});
+
+export const OpenEpdMaterial =
+  (mongoose.models.OpenEpdMaterial as OpenEpdMaterialModel) ||
+  mongoose.model<IOpenEpdMaterial, OpenEpdMaterialModel>(
+    "OpenEpdMaterial",
+    openEpdSchema,
+    "indicatorsOpenEpd"
+  );


### PR DESCRIPTION
Implements a unified adapter pattern for LCA (Life Cycle Assessment) data from multiple sources:

- KBOB (Switzerland): Swiss construction materials database with GWP, UBP, and PENRE indicators. Requires API key.
- ÖKOBAUDAT (Germany): German national EPD database with GWP and PENRE. Free API access.
- OpenEPD/EC3 (Global): Building Transparency database with GWP. Requires free API key.

Changes include:
- New ILcaDataService interface for standardized data access
- Service implementations for each data source with caching
- LcaSourceSelector component for dataset switching in UI
- Updated Material schema with lcaMatch subdocument for multi-source refs
- Unified /api/lca-materials endpoint for searching across sources
- Updated materials matching to support all three sources
- Backward compatibility with existing kbobMatchId references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-source LCA support: KBOB, ÖKOBAUDAT, OpenEPD
  * New source selector UI for choosing LCA database
  * Unified LCA search and cross-source aggregation
  * Enhanced material matching to store and use LCA matches with indicators (GWP/UBP/PENRE)
  * Materials library shows per-source metadata, density and indicator details

* **Stability**
  * Improved sync/search reliability and clearer error responses for LCA flows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->